### PR TITLE
WIP: Adding Mythic Run Overview to Event Overview Page

### DIFF
--- a/app/lib/mythics.ts
+++ b/app/lib/mythics.ts
@@ -1,10 +1,4 @@
-import {
-    OptionalCharacterProfilePayloadOptions,
-    OptionalCharacterProfilePayloadFields,
-    CharacterProfilePayload,
-    CharacterPayloadBase,
-    MythicPlusRun
-} from "~/lib/raiderIO/characters";
+import type { CharacterNS } from "~/lib/raiderIO/characters";
 import {RaiderIOClient} from "~/lib/raiderIO";
 
 export type DBPlayerInternalTeamType = {
@@ -39,7 +33,7 @@ export type DBTeamType = {
     players: DBPlayerType[]
 };
 
-export type MythicData = MythicPlusRun & {
+export type MythicData = CharacterNS.MythicPlusRun & {
     participants: DBPlayerType[]
 };
 
@@ -50,7 +44,7 @@ export function getPlayersPromises(team: DBTeamType | null, client: RaiderIOClie
         return playersPromises;
     }
 
-    const playersPromises: (Promise<null> | Promise<CharacterProfilePayload<OptionalCharacterProfilePayloadOptions>>)[] =
+    const playersPromises: (Promise<null> | Promise<CharacterNS.CharacterProfilePayload<CharacterNS.OptionalCharacterProfilePayloadOptions>>)[] =
         team.players.map((player) =>
             player.playerServer && player.playerName
                 ? client.character.getCharacterProfile({
@@ -73,7 +67,7 @@ export function getPlayersPromises(team: DBTeamType | null, client: RaiderIOClie
     return playersPromises;
 }
 
-export async function parseMythicDataPerTeam(team: DBTeamType | null, playersPromises: (Promise<null> | Promise<CharacterProfilePayload<OptionalCharacterProfilePayloadOptions>>)[]) {
+export async function parseMythicDataPerTeam(team: DBTeamType | null, playersPromises: (Promise<null> | Promise<CharacterNS.CharacterProfilePayload<CharacterNS.OptionalCharacterProfilePayloadOptions>>)[]) {
 
     if(!team) {
         const promiseOfAllMythicData: Promise<null> = Promise.resolve(null);
@@ -92,18 +86,14 @@ export async function parseMythicDataPerTeam(team: DBTeamType | null, playersPro
         // console.log("Mythics Promise", res);
         if (!res) return res;
 
-        const succeededRes: ((CharacterPayloadBase & OptionalCharacterProfilePayloadFields) | null)[] = res
+        const succeededRes: ((CharacterNS.CharacterPayloadBase & CharacterNS.OptionalCharacterProfilePayloadFields) | null)[] = res
             .filter((r) => r.status === "fulfilled")
             .map((r) => r.value);
 
-        // type MythicType = NonNullable<
-        //     (typeof succeededRes)[number]
-        // >["mythic_plus_best_runs"][number];
-
-        const mythicMap = new Map<number, MythicPlusRun>();
+        const mythicMap = new Map<number, CharacterNS.MythicPlusRun>();
         const participantMap = new Map<number, string[]>();
 
-        succeededRes.forEach((player: ((CharacterPayloadBase & OptionalCharacterProfilePayloadFields) | null)) => {
+        succeededRes.forEach((player: ((CharacterNS.CharacterPayloadBase & CharacterNS.OptionalCharacterProfilePayloadFields) | null)) => {
             if (!player) return;
             // We just want to resolve via the dbPlayer ID so we find and ensure we have that.
             const dbPlayer: DBPlayerType | undefined = playersOnTeam.find(({ playerName, playerServer }) => {
@@ -142,9 +132,6 @@ export async function parseMythicDataPerTeam(team: DBTeamType | null, playersPro
                 }
             });
         });
-
-        // console.log("Mythic Map", mythicMap);
-        // console.log("Participant Map", participantMap);
 
         // A mythic counts if at least 4 players of the team are in it.
         const mythics: MythicData[]  = Array.from(mythicMap.values())

--- a/app/lib/mythics.ts
+++ b/app/lib/mythics.ts
@@ -188,7 +188,7 @@ export function calculateBestMythicsAndTotalScore(mythics: MythicData[]) {
 
 export function calculateBestScoreAndBestUnderTime(mythics: MythicData[]) {
     const bestSingleScore = mythics.reduce(
-        (score: any, m: any) => (score > m.score ? score : m.score),
+        (score: number, m: MythicData) => (score > m.score ? score : m.score),
         0
     );
 

--- a/app/lib/mythics.ts
+++ b/app/lib/mythics.ts
@@ -1,0 +1,138 @@
+export async function ParseMythicDataPerTeam(players: any, playersPromises: any) {
+    // const players = serverRes.team.players;
+    const playersMap = new Map<string, (typeof players)[number]>();
+    players.forEach((p: any) => playersMap.set(p.id, p));
+
+    // Set these promises up in the client loader so they are stable in the react application.
+    const allPlayersPromise = Promise.allSettled(playersPromises);
+    const mythicsPromise = allPlayersPromise.then((res) => { // console.log("Mythics Promise", res);
+        if (!res) return res;
+
+        const succeededRes = res
+            .filter((r: any) => r.status === "fulfilled")
+            .map((r: any) => r.value);
+
+        type MythicType = NonNullable<
+            (typeof succeededRes)[number]
+        >["mythic_plus_best_runs"][number];
+
+        const mythicMap = new Map<number, MythicType>();
+        const participantMap = new Map<number, string[]>();
+        // console.log("DB Players", players);
+
+        succeededRes.forEach((player: any) => {
+            if (!player) return;
+            // We just want to resolve via the dbPlayer ID so we find and ensure we have that.
+            const dbPlayer = players.find(({ playerName, playerServer }) => {
+                // Strip whitespace and replace lowercase to slugify everything for more accurate
+                // matching. This should be fine since names are not case-sensitive.
+                const strip = (str: string | undefined | null) =>
+                    str?.toLocaleLowerCase()?.replace(/\s/, "");
+
+                return (
+                    strip(playerName) === strip(player.name) &&
+                    strip(playerServer) === strip(player.realm)
+                );
+            });
+            // console.log("DB Player", dbPlayer, player.name, player.realm);
+            if (!dbPlayer) return;
+
+            const allMythics = [
+                ...(player.mythic_plus_best_runs ?? []),
+                ...(player.mythic_plus_alternate_runs ?? []),
+                ...(player.mythic_plus_highest_level_runs ?? []),
+                ...(player.mythic_plus_recent_runs ?? []),
+                ...(player.mythic_plus_previous_weekly_highest_level_runs ?? []),
+                ...(player.mythic_plus_weekly_highest_level_runs ?? []),
+            ];
+
+            allMythics.forEach((run) => {
+                mythicMap.set(run.keystone_run_id, run);
+
+                const participantsList = participantMap.get(run.keystone_run_id);
+
+                // Ensure this player is in the participant list
+                if (!participantsList) {
+                    participantMap.set(run.keystone_run_id, [dbPlayer.id]);
+                } else if (participantsList.findIndex((id) => id === dbPlayer.id) < 0) {
+                    participantsList.push(dbPlayer.id);
+                }
+            });
+        });
+
+        // console.log("Mythic Map", mythicMap);
+        // console.log("Participant Map", participantMap);
+
+        // A mythic counts if at least 4 players of the team are in it.
+        const mythics = Array.from(mythicMap.values())
+            .flatMap((m) => {
+                const participants = participantMap.get(m.keystone_run_id);
+
+                // If there were no participants or not enough participants this does not count as a key for this team.
+                if (!participants || participants.length < 4) {
+                  return [];
+                }
+
+                return [
+                    {
+                        ...m,
+                        participants: participants
+                            .map((p) => playersMap.get(p))
+                            .filter((p) => p !== undefined),
+                    },
+                ];
+            })
+            .sort(
+                (mythicA, mythicB) =>
+                    // First sort descending on the keystone level so higher keystones are at the top.
+                    mythicB.mythic_level - mythicA.mythic_level ||
+                    // Next descending by score.
+                    mythicB.score - mythicA.score ||
+                    // Finally sort ascending within the score and mythic level category by string.
+                    mythicA.short_name.localeCompare(mythicB.short_name)
+            );
+
+        return mythics;
+    });
+
+    return {
+        allPlayersPromise,
+        mythicsPromise,
+    };
+}
+
+export function CalculateBestMythicsAndTotalScore(mythics: any) {
+    const bestMythicsMap = {} as Record<string, (typeof mythics)[number]>;
+
+    mythics.forEach((m: any) => {
+        const existing = bestMythicsMap[m.dungeon];
+
+        // TODO: Maybe incorporate the most recent run into this somehow?
+        if (!existing || existing.score < m.score) {
+            bestMythicsMap[m.dungeon] = m;
+        }
+    });
+
+    const bestMythics = Object.values(bestMythicsMap);
+    const totalScore = bestMythics.reduce((acc, m) => acc + m.score, 0);
+
+    return [Object.values(bestMythicsMap), totalScore] as const;
+}
+
+export function CalculateBestScoreAndBestUnderTime(mythics: any) {
+    const bestSingleScore = mythics.reduce(
+        (score: any, m: any) => (score > m.score ? score : m.score),
+        0
+    );
+
+    const mostUnderTime = mythics.reduce((curr: any, m: any) => {
+        const percentUnder = (m.clear_time_ms - m.par_time_ms) / m.par_time_ms;
+
+        if (percentUnder > curr) {
+            return percentUnder;
+        } else {
+            return curr;
+        }
+    }, 0);
+    return [bestSingleScore, mostUnderTime] as const;
+}

--- a/app/lib/raiderIO/characters.ts
+++ b/app/lib/raiderIO/characters.ts
@@ -2,346 +2,344 @@ import type { RaiderIOClient } from ".";
 import type { RootNS } from "./index";
 import { fieldsString, HasChildBool } from "./utils";
 
-export namespace CharacterNS {
-  type CharacterPayloadBase = {
-    name: string;
-    race: RootNS.Race;
-    class: RootNS.Class;
-    active_spec_name: RootNS.Spec;
-    active_spec_role: RootNS.Role;
-    gender: string;
-    faction: RootNS.Faction;
-    achievement_points: number;
-    thumbnail_url: string;
-    region: RootNS.Region;
-    realm: RootNS.Realm;
-    last_crawled_at: RootNS.DateTime;
-    profile_url: string;
-    profile_banner: string;
-  };
+export type CharacterPayloadBase = {
+  name: string;
+  race: RootNS.Race;
+  class: RootNS.Class;
+  active_spec_name: RootNS.Spec;
+  active_spec_role: RootNS.Role;
+  gender: string;
+  faction: RootNS.Faction;
+  achievement_points: number;
+  thumbnail_url: string;
+  region: RootNS.Region;
+  realm: RootNS.Realm;
+  last_crawled_at: RootNS.DateTime;
+  profile_url: string;
+  profile_banner: string;
+};
 
-  interface GearSpell {
-    id: number;
-    school: number;
-    icon: string;
-    name: string;
-    rank: string | null;
-  }
+interface GearSpell {
+  id: number;
+  school: number;
+  icon: string;
+  name: string;
+  rank: string | null;
+}
 
-  interface AzeritePower {
-    id: number;
-    spell: GearSpell;
-    tier: number;
-  }
+interface AzeritePower {
+  id: number;
+  spell: GearSpell;
+  tier: number;
+}
 
-  interface Corruption {
+interface Corruption {
+  added: number;
+  resisted: number;
+  total: number;
+}
+
+export interface Item {
+  item_id: number;
+  item_level: number;
+  icon: string;
+  name: string;
+  item_quality: number;
+  is_legendary: boolean;
+  is_azerite_armor: boolean;
+  azerite_powers: Array<AzeritePower | null>;
+  corruption: Corruption;
+  domination_shards: unknown[]; // currently empty—replace `unknown` when you know the shape
+  tier: string;
+  gems: unknown[]; // ditto
+  enchants: unknown[];
+  bonuses: number[];
+}
+
+type GearType = {
+  created_at: RootNS.DateTime;
+  updated_at: RootNS.DateTime;
+  source: string;
+  item_level_equipped: number;
+  item_level_total: number;
+  artifact_traits: number;
+  corruption: {
     added: number;
     resisted: number;
     total: number;
-  }
-
-  export interface Item {
-    item_id: number;
-    item_level: number;
-    icon: string;
-    name: string;
-    item_quality: number;
-    is_legendary: boolean;
-    is_azerite_armor: boolean;
-    azerite_powers: Array<AzeritePower | null>;
-    corruption: Corruption;
-    domination_shards: unknown[]; // currently empty—replace `unknown` when you know the shape
-    tier: string;
-    gems: unknown[]; // ditto
-    enchants: unknown[];
-    bonuses: number[];
-  }
-
-  type GearType = {
-    created_at: RootNS.DateTime;
-    updated_at: RootNS.DateTime;
-    source: string;
-    item_level_equipped: number;
-    item_level_total: number;
-    artifact_traits: number;
-    corruption: {
-      added: number;
-      resisted: number;
-      total: number;
-      cloakRank: number;
-      spells: unknown[];
-    };
-    items: {
-      head: Item;
-      neck: Item;
-      shoulder: Item;
-      back: Item;
-      chest: Item;
-      shirt: Item;
-      wrist: Item;
-      hands: Item;
-      waist: Item;
-      legs: Item;
-      feet: Item;
-      ring1: Item;
-      ring2: Item;
-      trinket1: Item;
-      trinket2: Item;
-      mainhand: Item;
-      offhand: Item;
-    };
+    cloakRank: number;
+    spells: unknown[];
   };
-
-  interface LoadoutEntry {
-    node: TalentNode;
-    entryIndex: number;
-    rank: number;
-  }
-
-  interface TalentNode {
-    id: number;
-    treeId: number;
-    subTreeId: number;
-    type: number;
-    entries: TalentEntry[];
-    important: boolean;
-    posX: number;
-    posY: number;
-    row: number;
-    col: number;
-  }
-
-  interface TalentEntry {
-    id: number;
-    traitDefinitionId: number;
-    traitSubTreeId: number;
-    type: number;
-    maxRanks: number;
-    spell: TalentSpell | null;
-  }
-
-  interface TalentSpell {
-    id: number;
-    name: string;
-    icon: string;
-    school: number;
-    rank: string | null;
-    hasCooldown: boolean;
-  }
-
-  type TalentType = {
-    loadout_spec_id: number;
-    loadout_text: string;
-    loadout: LoadoutEntry[];
+  items: {
+    head: Item;
+    neck: Item;
+    shoulder: Item;
+    back: Item;
+    chest: Item;
+    shirt: Item;
+    wrist: Item;
+    hands: Item;
+    waist: Item;
+    legs: Item;
+    feet: Item;
+    ring1: Item;
+    ring2: Item;
+    trinket1: Item;
+    trinket2: Item;
+    mainhand: Item;
+    offhand: Item;
   };
+};
 
-  type GuildType = {
-    name: string;
-    realm: RootNS.Realm;
-  };
-
-  type CovenantType = unknown;
-
-  type RaidType = {
-    summary: string;
-    expansion_id: number;
-    total_bosses: number;
-    normal_bosses_killed: number;
-    heroic_bosses_killed: number;
-    mythic_bosses_killed: number;
-  };
-
-  // Could maybe narrow this to "liberation-of-undermine" and stuff.
-  type RaidProgressionType = {
-    [key: RootNS.Raid]: RaidType;
-  };
-
-  type MythicPlusSegmentType = {
-    score: number;
-    color: string;
-  };
-
-  type MythicPlusScoresBySeasonType = {
-    season: string;
-    scores: {
-      all: number;
-      dps: number;
-      healer: number;
-      tank: number;
-      dps_0: number;
-      dps_1: number;
-      dps_2: number;
-      dps_3: number;
-    };
-    segments: {
-      all: MythicPlusSegmentType;
-      dps: MythicPlusSegmentType;
-      healer: MythicPlusSegmentType;
-      tank: MythicPlusSegmentType;
-      dps_0: MythicPlusSegmentType;
-      dps_1: MythicPlusSegmentType;
-      dps_2: MythicPlusSegmentType;
-      dps_3: MythicPlusSegmentType;
-    };
-  }[];
-
-  type MythicPlusRankType = {
-    world: number;
-    region: number;
-    realm: number;
-  };
-
-  type MythicPlusRanksType = {
-    overall: MythicPlusRankType;
-    dps?: MythicPlusRankType;
-    healer?: MythicPlusRankType;
-    tank?: MythicPlusRankType;
-    class_tank?: MythicPlusRankType;
-    class_dps?: MythicPlusRankType;
-    class_healer?: MythicPlusRankType;
-  } & Record<`spec_${number}`, MythicPlusRankType>;
-
-  export interface MythicPlusRun {
-    dungeon: string;
-    short_name: string;
-    mythic_level: number;
-    completed_at: RootNS.DateTime; // ISO 8601 timestamp
-    clear_time_ms: number;
-    keystone_run_id: number;
-    par_time_ms: number;
-    num_keystone_upgrades: number;
-    map_challenge_mode_id: number;
-    zone_id: number;
-    zone_expansion_id: number;
-    icon_url: string;
-    background_image_url: string;
-    score: number;
-    affixes: Affix[];
-    url: string;
-  }
-
-  export interface Affix {
-    id: number;
-    name: string;
-    description: string;
-    icon: string;
-    icon_url: string;
-    wowhead_url: string;
-  }
-
-  type MythicPlusRecentRunsType = MythicPlusRun[];
-  type MythicPlusBestRunsType = MythicPlusRun[];
-  type MythicPlusAlternateRunsType = MythicPlusRun[];
-  type MythicPlusHighestLevelRunsType = MythicPlusRun[];
-  type MythicPlusWeeklyHighestLevelRunsType = MythicPlusRun[];
-  type MythicPlusPreviousWeeklyHighestLevelRunsType = MythicPlusRun[];
-  type PreviousMythicPlusRanksType = MythicPlusRanksType;
-  // Both of these are unknown as nothing seemed to be returned.
-  type RaidMetaAchievementType = unknown;
-  type RaidAchievementCurveType = unknown;
-
-  type OptionalCharacterProfilePayloadFields = {
-    gear: GearType;
-    talents: TalentType;
-    guild: GuildType;
-    covenant: CovenantType;
-    raid_progression: RaidProgressionType;
-    mythic_plus_scores_by_season: MythicPlusScoresBySeasonType;
-    mythic_plus_ranks: MythicPlusRanksType;
-    mythic_plus_recent_runs: MythicPlusRecentRunsType;
-    mythic_plus_best_runs: MythicPlusBestRunsType;
-    mythic_plus_alternate_runs: MythicPlusAlternateRunsType;
-    mythic_plus_highest_level_runs: MythicPlusHighestLevelRunsType;
-    mythic_plus_weekly_highest_level_runs: MythicPlusWeeklyHighestLevelRunsType;
-    mythic_plus_previous_weekly_highest_level_runs: MythicPlusPreviousWeeklyHighestLevelRunsType;
-    previous_mythic_plus_ranks: PreviousMythicPlusRanksType;
-    raid_achievement_meta: RaidMetaAchievementType;
-    raid_achievement_curve: RaidAchievementCurveType;
-  };
-
-  // This entire hash is just for the fact that talents does not match the output key.
-  // As far as I can tell every other key matches the key in the output.
-  type OutputKey = {
-    gear: "gear";
-    talents: "talentLoadout";
-    guild: "guild";
-    covenant: "covenant";
-    raid_progression: "raid_progression";
-    mythic_plus_scores_by_season: "mythic_plus_scores_by_season";
-    mythic_plus_ranks: "mythic_plus_ranks";
-    mythic_plus_recent_runs: "mythic_plus_recent_runs";
-    mythic_plus_best_runs: "mythic_plus_best_runs";
-    mythic_plus_alternate_runs: "mythic_plus_alternate_runs";
-    mythic_plus_highest_level_runs: "mythic_plus_highest_level_runs";
-    mythic_plus_weekly_highest_level_runs: "mythic_plus_weekly_highest_level_runs";
-    mythic_plus_previous_weekly_highest_level_runs: "mythic_plus_previous_weekly_highest_level_runs";
-    previous_mythic_plus_ranks: "previous_mythic_plus_ranks";
-    raid_achievement_meta: "raid_achievement_meta";
-    raid_achievement_curve: "raid_achievement_curve";
-  };
-
-  export type OptionalCharacterProfilePayloadOptions = {
-    gear?: boolean;
-    talents?:
-      | boolean
-      | {
-          categorized: true;
-        };
-    guild?: boolean;
-    covenant?: boolean;
-    raid_progression?:
-      | boolean
-      | {
-          [
-            key:
-              | string
-              | number
-              | "current-expansion"
-              | "previous-expansion"
-              | "current-tier"
-              | "previous-tier"
-          ]: boolean;
-        };
-    mythic_plus_scores_by_season?:
-      | boolean
-      | {
-          [key: "current" | "previous" | `season-${string}` | string]: boolean;
-        };
-    mythic_plus_ranks?: boolean;
-    mythic_plus_recent_runs?: boolean;
-    mythic_plus_best_runs?:
-      | boolean
-      | {
-          all: boolean;
-        };
-    mythic_plus_alternate_runs?:
-      | boolean
-      | {
-          all: boolean;
-        };
-    mythic_plus_highest_level_runs?: boolean;
-    mythic_plus_weekly_highest_level_runs?: boolean;
-    mythic_plus_previous_weekly_highest_level_runs?: boolean;
-    previous_mythic_plus_ranks?: boolean;
-    raid_achievement_meta?: {
-      [key: `tier${number}`]: boolean;
-    };
-    raid_achievement_curve?: {
-      [key: `tier${number}`]: boolean;
-    };
-  };
-
-  // Build up the output hash with only the keys that are requested.
-  export type CharacterProfilePayload<
-    T extends OptionalCharacterProfilePayloadOptions
-  > = CharacterPayloadBase & {
-    [key in keyof OptionalCharacterProfilePayloadFields as HasChildBool<
-      T[key]
-    > extends true
-      ? OutputKey[key]
-      : never]: OptionalCharacterProfilePayloadFields[key];
-  };
+interface LoadoutEntry {
+  node: TalentNode;
+  entryIndex: number;
+  rank: number;
 }
+
+interface TalentNode {
+  id: number;
+  treeId: number;
+  subTreeId: number;
+  type: number;
+  entries: TalentEntry[];
+  important: boolean;
+  posX: number;
+  posY: number;
+  row: number;
+  col: number;
+}
+
+interface TalentEntry {
+  id: number;
+  traitDefinitionId: number;
+  traitSubTreeId: number;
+  type: number;
+  maxRanks: number;
+  spell: TalentSpell | null;
+}
+
+interface TalentSpell {
+  id: number;
+  name: string;
+  icon: string;
+  school: number;
+  rank: string | null;
+  hasCooldown: boolean;
+}
+
+type TalentType = {
+  loadout_spec_id: number;
+  loadout_text: string;
+  loadout: LoadoutEntry[];
+};
+
+type GuildType = {
+  name: string;
+  realm: RootNS.Realm;
+};
+
+type CovenantType = unknown;
+
+type RaidType = {
+  summary: string;
+  expansion_id: number;
+  total_bosses: number;
+  normal_bosses_killed: number;
+  heroic_bosses_killed: number;
+  mythic_bosses_killed: number;
+};
+
+// Could maybe narrow this to "liberation-of-undermine" and stuff.
+type RaidProgressionType = {
+  [key: RootNS.Raid]: RaidType;
+};
+
+type MythicPlusSegmentType = {
+  score: number;
+  color: string;
+};
+
+type MythicPlusScoresBySeasonType = {
+  season: string;
+  scores: {
+    all: number;
+    dps: number;
+    healer: number;
+    tank: number;
+    dps_0: number;
+    dps_1: number;
+    dps_2: number;
+    dps_3: number;
+  };
+  segments: {
+    all: MythicPlusSegmentType;
+    dps: MythicPlusSegmentType;
+    healer: MythicPlusSegmentType;
+    tank: MythicPlusSegmentType;
+    dps_0: MythicPlusSegmentType;
+    dps_1: MythicPlusSegmentType;
+    dps_2: MythicPlusSegmentType;
+    dps_3: MythicPlusSegmentType;
+  };
+}[];
+
+type MythicPlusRankType = {
+  world: number;
+  region: number;
+  realm: number;
+};
+
+type MythicPlusRanksType = {
+  overall: MythicPlusRankType;
+  dps?: MythicPlusRankType;
+  healer?: MythicPlusRankType;
+  tank?: MythicPlusRankType;
+  class_tank?: MythicPlusRankType;
+  class_dps?: MythicPlusRankType;
+  class_healer?: MythicPlusRankType;
+} & Record<`spec_${number}`, MythicPlusRankType>;
+
+export interface MythicPlusRun {
+  dungeon: string;
+  short_name: string;
+  mythic_level: number;
+  completed_at: RootNS.DateTime; // ISO 8601 timestamp
+  clear_time_ms: number;
+  keystone_run_id: number;
+  par_time_ms: number;
+  num_keystone_upgrades: number;
+  map_challenge_mode_id: number;
+  zone_id: number;
+  zone_expansion_id: number;
+  icon_url: string;
+  background_image_url: string;
+  score: number;
+  affixes: Affix[];
+  url: string;
+}
+
+export interface Affix {
+  id: number;
+  name: string;
+  description: string;
+  icon: string;
+  icon_url: string;
+  wowhead_url: string;
+}
+
+type MythicPlusRecentRunsType = MythicPlusRun[];
+type MythicPlusBestRunsType = MythicPlusRun[];
+type MythicPlusAlternateRunsType = MythicPlusRun[];
+type MythicPlusHighestLevelRunsType = MythicPlusRun[];
+type MythicPlusWeeklyHighestLevelRunsType = MythicPlusRun[];
+type MythicPlusPreviousWeeklyHighestLevelRunsType = MythicPlusRun[];
+type PreviousMythicPlusRanksType = MythicPlusRanksType;
+// Both of these are unknown as nothing seemed to be returned.
+type RaidMetaAchievementType = unknown;
+type RaidAchievementCurveType = unknown;
+
+export type OptionalCharacterProfilePayloadFields = {
+  gear?: GearType;
+  talents?: TalentType;
+  guild?: GuildType;
+  covenant?: CovenantType;
+  raid_progression?: RaidProgressionType;
+  mythic_plus_scores_by_season?: MythicPlusScoresBySeasonType;
+  mythic_plus_ranks?: MythicPlusRanksType;
+  mythic_plus_recent_runs?: MythicPlusRecentRunsType;
+  mythic_plus_best_runs?: MythicPlusBestRunsType;
+  mythic_plus_alternate_runs?: MythicPlusAlternateRunsType;
+  mythic_plus_highest_level_runs?: MythicPlusHighestLevelRunsType;
+  mythic_plus_weekly_highest_level_runs?: MythicPlusWeeklyHighestLevelRunsType;
+  mythic_plus_previous_weekly_highest_level_runs?: MythicPlusPreviousWeeklyHighestLevelRunsType;
+  previous_mythic_plus_ranks?: PreviousMythicPlusRanksType;
+  raid_achievement_meta?: RaidMetaAchievementType;
+  raid_achievement_curve?: RaidAchievementCurveType;
+};
+
+// This entire hash is just for the fact that talents does not match the output key.
+// As far as I can tell every other key matches the key in the output.
+type OutputKey = {
+  gear: "gear";
+  talents: "talentLoadout";
+  guild: "guild";
+  covenant: "covenant";
+  raid_progression: "raid_progression";
+  mythic_plus_scores_by_season: "mythic_plus_scores_by_season";
+  mythic_plus_ranks: "mythic_plus_ranks";
+  mythic_plus_recent_runs: "mythic_plus_recent_runs";
+  mythic_plus_best_runs: "mythic_plus_best_runs";
+  mythic_plus_alternate_runs: "mythic_plus_alternate_runs";
+  mythic_plus_highest_level_runs: "mythic_plus_highest_level_runs";
+  mythic_plus_weekly_highest_level_runs: "mythic_plus_weekly_highest_level_runs";
+  mythic_plus_previous_weekly_highest_level_runs: "mythic_plus_previous_weekly_highest_level_runs";
+  previous_mythic_plus_ranks: "previous_mythic_plus_ranks";
+  raid_achievement_meta: "raid_achievement_meta";
+  raid_achievement_curve: "raid_achievement_curve";
+};
+
+export type OptionalCharacterProfilePayloadOptions = {
+  gear?: boolean;
+  talents?:
+    | boolean
+    | {
+        categorized: true;
+      };
+  guild?: boolean;
+  covenant?: boolean;
+  raid_progression?:
+    | boolean
+    | {
+        [
+          key:
+            | string
+            | number
+            | "current-expansion"
+            | "previous-expansion"
+            | "current-tier"
+            | "previous-tier"
+        ]: boolean;
+      };
+  mythic_plus_scores_by_season?:
+    | boolean
+    | {
+        [key: "current" | "previous" | `season-${string}` | string]: boolean;
+      };
+  mythic_plus_ranks?: boolean;
+  mythic_plus_recent_runs?: boolean;
+  mythic_plus_best_runs?:
+    | boolean
+    | {
+        all: boolean;
+      };
+  mythic_plus_alternate_runs?:
+    | boolean
+    | {
+        all: boolean;
+      };
+  mythic_plus_highest_level_runs?: boolean;
+  mythic_plus_weekly_highest_level_runs?: boolean;
+  mythic_plus_previous_weekly_highest_level_runs?: boolean;
+  previous_mythic_plus_ranks?: boolean;
+  raid_achievement_meta?: {
+    [key: `tier${number}`]: boolean;
+  };
+  raid_achievement_curve?: {
+    [key: `tier${number}`]: boolean;
+  };
+};
+
+// Build up the output hash with only the keys that are requested.
+export type CharacterProfilePayload<
+  T extends OptionalCharacterProfilePayloadOptions
+> = CharacterPayloadBase & {
+  [key in keyof OptionalCharacterProfilePayloadFields as HasChildBool<
+    T[key]
+  > extends true
+    ? OutputKey[key]
+    : never]: OptionalCharacterProfilePayloadFields[key];
+};
 
 export class Character {
   private client: RaiderIOClient;
@@ -351,7 +349,7 @@ export class Character {
   }
 
   async getCharacterProfile<
-    T extends CharacterNS.OptionalCharacterProfilePayloadOptions
+    T extends OptionalCharacterProfilePayloadOptions
   >({
     region,
     realm,
@@ -362,7 +360,7 @@ export class Character {
     realm: string;
     name: string;
     fields?: T;
-  }): Promise<CharacterNS.CharacterProfilePayload<T>> {
+  }): Promise<CharacterProfilePayload<T>> {
     return this.client.get("/characters/profile", {
       params: {
         region,
@@ -374,7 +372,7 @@ export class Character {
   }
 
   async getCharacterProfiles<
-    T extends CharacterNS.OptionalCharacterProfilePayloadOptions
+    T extends OptionalCharacterProfilePayloadOptions
   >({
     characters,
   }: {
@@ -384,7 +382,7 @@ export class Character {
       name: string;
       fields?: T;
     }[];
-  }): Promise<CharacterNS.CharacterProfilePayload<T>[]> {
+  }): Promise<CharacterProfilePayload<T>[]> {
     return Promise.all(
       characters.map((character) => this.getCharacterProfile(character))
     );

--- a/app/lib/raiderIO/characters.ts
+++ b/app/lib/raiderIO/characters.ts
@@ -2,343 +2,346 @@ import type { RaiderIOClient } from ".";
 import type { RootNS } from "./index";
 import { fieldsString, HasChildBool } from "./utils";
 
-export type CharacterPayloadBase = {
-  name: string;
-  race: RootNS.Race;
-  class: RootNS.Class;
-  active_spec_name: RootNS.Spec;
-  active_spec_role: RootNS.Role;
-  gender: string;
-  faction: RootNS.Faction;
-  achievement_points: number;
-  thumbnail_url: string;
-  region: RootNS.Region;
-  realm: RootNS.Realm;
-  last_crawled_at: RootNS.DateTime;
-  profile_url: string;
-  profile_banner: string;
-};
+export namespace CharacterNS
+{
+  export type CharacterPayloadBase = {
+    name: string;
+    race: RootNS.Race;
+    class: RootNS.Class;
+    active_spec_name: RootNS.Spec;
+    active_spec_role: RootNS.Role;
+    gender: string;
+    faction: RootNS.Faction;
+    achievement_points: number;
+    thumbnail_url: string;
+    region: RootNS.Region;
+    realm: RootNS.Realm;
+    last_crawled_at: RootNS.DateTime;
+    profile_url: string;
+    profile_banner: string;
+  };
 
-interface GearSpell {
-  id: number;
-  school: number;
-  icon: string;
-  name: string;
-  rank: string | null;
-}
+  interface GearSpell {
+    id: number;
+    school: number;
+    icon: string;
+    name: string;
+    rank: string | null;
+  }
 
-interface AzeritePower {
-  id: number;
-  spell: GearSpell;
-  tier: number;
-}
+  interface AzeritePower {
+    id: number;
+    spell: GearSpell;
+    tier: number;
+  }
 
-interface Corruption {
-  added: number;
-  resisted: number;
-  total: number;
-}
-
-export interface Item {
-  item_id: number;
-  item_level: number;
-  icon: string;
-  name: string;
-  item_quality: number;
-  is_legendary: boolean;
-  is_azerite_armor: boolean;
-  azerite_powers: Array<AzeritePower | null>;
-  corruption: Corruption;
-  domination_shards: unknown[]; // currently empty—replace `unknown` when you know the shape
-  tier: string;
-  gems: unknown[]; // ditto
-  enchants: unknown[];
-  bonuses: number[];
-}
-
-type GearType = {
-  created_at: RootNS.DateTime;
-  updated_at: RootNS.DateTime;
-  source: string;
-  item_level_equipped: number;
-  item_level_total: number;
-  artifact_traits: number;
-  corruption: {
+  interface Corruption {
     added: number;
     resisted: number;
     total: number;
-    cloakRank: number;
-    spells: unknown[];
+  }
+
+  export interface Item {
+    item_id: number;
+    item_level: number;
+    icon: string;
+    name: string;
+    item_quality: number;
+    is_legendary: boolean;
+    is_azerite_armor: boolean;
+    azerite_powers: Array<AzeritePower | null>;
+    corruption: Corruption;
+    domination_shards: unknown[]; // currently empty—replace `unknown` when you know the shape
+    tier: string;
+    gems: unknown[]; // ditto
+    enchants: unknown[];
+    bonuses: number[];
+  }
+
+  type GearType = {
+    created_at: RootNS.DateTime;
+    updated_at: RootNS.DateTime;
+    source: string;
+    item_level_equipped: number;
+    item_level_total: number;
+    artifact_traits: number;
+    corruption: {
+      added: number;
+      resisted: number;
+      total: number;
+      cloakRank: number;
+      spells: unknown[];
+    };
+    items: {
+      head: Item;
+      neck: Item;
+      shoulder: Item;
+      back: Item;
+      chest: Item;
+      shirt: Item;
+      wrist: Item;
+      hands: Item;
+      waist: Item;
+      legs: Item;
+      feet: Item;
+      ring1: Item;
+      ring2: Item;
+      trinket1: Item;
+      trinket2: Item;
+      mainhand: Item;
+      offhand: Item;
+    };
   };
-  items: {
-    head: Item;
-    neck: Item;
-    shoulder: Item;
-    back: Item;
-    chest: Item;
-    shirt: Item;
-    wrist: Item;
-    hands: Item;
-    waist: Item;
-    legs: Item;
-    feet: Item;
-    ring1: Item;
-    ring2: Item;
-    trinket1: Item;
-    trinket2: Item;
-    mainhand: Item;
-    offhand: Item;
+
+  interface LoadoutEntry {
+    node: TalentNode;
+    entryIndex: number;
+    rank: number;
+  }
+
+  interface TalentNode {
+    id: number;
+    treeId: number;
+    subTreeId: number;
+    type: number;
+    entries: TalentEntry[];
+    important: boolean;
+    posX: number;
+    posY: number;
+    row: number;
+    col: number;
+  }
+
+  interface TalentEntry {
+    id: number;
+    traitDefinitionId: number;
+    traitSubTreeId: number;
+    type: number;
+    maxRanks: number;
+    spell: TalentSpell | null;
+  }
+
+  interface TalentSpell {
+    id: number;
+    name: string;
+    icon: string;
+    school: number;
+    rank: string | null;
+    hasCooldown: boolean;
+  }
+
+  type TalentType = {
+    loadout_spec_id: number;
+    loadout_text: string;
+    loadout: LoadoutEntry[];
   };
-};
 
-interface LoadoutEntry {
-  node: TalentNode;
-  entryIndex: number;
-  rank: number;
-}
-
-interface TalentNode {
-  id: number;
-  treeId: number;
-  subTreeId: number;
-  type: number;
-  entries: TalentEntry[];
-  important: boolean;
-  posX: number;
-  posY: number;
-  row: number;
-  col: number;
-}
-
-interface TalentEntry {
-  id: number;
-  traitDefinitionId: number;
-  traitSubTreeId: number;
-  type: number;
-  maxRanks: number;
-  spell: TalentSpell | null;
-}
-
-interface TalentSpell {
-  id: number;
-  name: string;
-  icon: string;
-  school: number;
-  rank: string | null;
-  hasCooldown: boolean;
-}
-
-type TalentType = {
-  loadout_spec_id: number;
-  loadout_text: string;
-  loadout: LoadoutEntry[];
-};
-
-type GuildType = {
-  name: string;
-  realm: RootNS.Realm;
-};
-
-type CovenantType = unknown;
-
-type RaidType = {
-  summary: string;
-  expansion_id: number;
-  total_bosses: number;
-  normal_bosses_killed: number;
-  heroic_bosses_killed: number;
-  mythic_bosses_killed: number;
-};
-
-// Could maybe narrow this to "liberation-of-undermine" and stuff.
-type RaidProgressionType = {
-  [key: RootNS.Raid]: RaidType;
-};
-
-type MythicPlusSegmentType = {
-  score: number;
-  color: string;
-};
-
-type MythicPlusScoresBySeasonType = {
-  season: string;
-  scores: {
-    all: number;
-    dps: number;
-    healer: number;
-    tank: number;
-    dps_0: number;
-    dps_1: number;
-    dps_2: number;
-    dps_3: number;
+  type GuildType = {
+    name: string;
+    realm: RootNS.Realm;
   };
-  segments: {
-    all: MythicPlusSegmentType;
-    dps: MythicPlusSegmentType;
-    healer: MythicPlusSegmentType;
-    tank: MythicPlusSegmentType;
-    dps_0: MythicPlusSegmentType;
-    dps_1: MythicPlusSegmentType;
-    dps_2: MythicPlusSegmentType;
-    dps_3: MythicPlusSegmentType;
+
+  type CovenantType = unknown;
+
+  type RaidType = {
+    summary: string;
+    expansion_id: number;
+    total_bosses: number;
+    normal_bosses_killed: number;
+    heroic_bosses_killed: number;
+    mythic_bosses_killed: number;
   };
-}[];
 
-type MythicPlusRankType = {
-  world: number;
-  region: number;
-  realm: number;
-};
+  // Could maybe narrow this to "liberation-of-undermine" and stuff.
+  type RaidProgressionType = {
+    [key: RootNS.Raid]: RaidType;
+  };
 
-type MythicPlusRanksType = {
-  overall: MythicPlusRankType;
-  dps?: MythicPlusRankType;
-  healer?: MythicPlusRankType;
-  tank?: MythicPlusRankType;
-  class_tank?: MythicPlusRankType;
-  class_dps?: MythicPlusRankType;
-  class_healer?: MythicPlusRankType;
-} & Record<`spec_${number}`, MythicPlusRankType>;
+  type MythicPlusSegmentType = {
+    score: number;
+    color: string;
+  };
 
-export interface MythicPlusRun {
-  dungeon: string;
-  short_name: string;
-  mythic_level: number;
-  completed_at: RootNS.DateTime; // ISO 8601 timestamp
-  clear_time_ms: number;
-  keystone_run_id: number;
-  par_time_ms: number;
-  num_keystone_upgrades: number;
-  map_challenge_mode_id: number;
-  zone_id: number;
-  zone_expansion_id: number;
-  icon_url: string;
-  background_image_url: string;
-  score: number;
-  affixes: Affix[];
-  url: string;
-}
+  type MythicPlusScoresBySeasonType = {
+    season: string;
+    scores: {
+      all: number;
+      dps: number;
+      healer: number;
+      tank: number;
+      dps_0: number;
+      dps_1: number;
+      dps_2: number;
+      dps_3: number;
+    };
+    segments: {
+      all: MythicPlusSegmentType;
+      dps: MythicPlusSegmentType;
+      healer: MythicPlusSegmentType;
+      tank: MythicPlusSegmentType;
+      dps_0: MythicPlusSegmentType;
+      dps_1: MythicPlusSegmentType;
+      dps_2: MythicPlusSegmentType;
+      dps_3: MythicPlusSegmentType;
+    };
+  }[];
 
-export interface Affix {
-  id: number;
-  name: string;
-  description: string;
-  icon: string;
-  icon_url: string;
-  wowhead_url: string;
-}
+  type MythicPlusRankType = {
+    world: number;
+    region: number;
+    realm: number;
+  };
 
-type MythicPlusRecentRunsType = MythicPlusRun[];
-type MythicPlusBestRunsType = MythicPlusRun[];
-type MythicPlusAlternateRunsType = MythicPlusRun[];
-type MythicPlusHighestLevelRunsType = MythicPlusRun[];
-type MythicPlusWeeklyHighestLevelRunsType = MythicPlusRun[];
-type MythicPlusPreviousWeeklyHighestLevelRunsType = MythicPlusRun[];
-type PreviousMythicPlusRanksType = MythicPlusRanksType;
-// Both of these are unknown as nothing seemed to be returned.
-type RaidMetaAchievementType = unknown;
-type RaidAchievementCurveType = unknown;
+  type MythicPlusRanksType = {
+    overall: MythicPlusRankType;
+    dps?: MythicPlusRankType;
+    healer?: MythicPlusRankType;
+    tank?: MythicPlusRankType;
+    class_tank?: MythicPlusRankType;
+    class_dps?: MythicPlusRankType;
+    class_healer?: MythicPlusRankType;
+  } & Record<`spec_${number}`, MythicPlusRankType>;
 
-export type OptionalCharacterProfilePayloadFields = {
-  gear?: GearType;
-  talents?: TalentType;
-  guild?: GuildType;
-  covenant?: CovenantType;
-  raid_progression?: RaidProgressionType;
-  mythic_plus_scores_by_season?: MythicPlusScoresBySeasonType;
-  mythic_plus_ranks?: MythicPlusRanksType;
-  mythic_plus_recent_runs?: MythicPlusRecentRunsType;
-  mythic_plus_best_runs?: MythicPlusBestRunsType;
-  mythic_plus_alternate_runs?: MythicPlusAlternateRunsType;
-  mythic_plus_highest_level_runs?: MythicPlusHighestLevelRunsType;
-  mythic_plus_weekly_highest_level_runs?: MythicPlusWeeklyHighestLevelRunsType;
-  mythic_plus_previous_weekly_highest_level_runs?: MythicPlusPreviousWeeklyHighestLevelRunsType;
-  previous_mythic_plus_ranks?: PreviousMythicPlusRanksType;
-  raid_achievement_meta?: RaidMetaAchievementType;
-  raid_achievement_curve?: RaidAchievementCurveType;
-};
+  export interface MythicPlusRun {
+    dungeon: string;
+    short_name: string;
+    mythic_level: number;
+    completed_at: RootNS.DateTime; // ISO 8601 timestamp
+    clear_time_ms: number;
+    keystone_run_id: number;
+    par_time_ms: number;
+    num_keystone_upgrades: number;
+    map_challenge_mode_id: number;
+    zone_id: number;
+    zone_expansion_id: number;
+    icon_url: string;
+    background_image_url: string;
+    score: number;
+    affixes: Affix[];
+    url: string;
+  }
 
-// This entire hash is just for the fact that talents does not match the output key.
-// As far as I can tell every other key matches the key in the output.
-type OutputKey = {
-  gear: "gear";
-  talents: "talentLoadout";
-  guild: "guild";
-  covenant: "covenant";
-  raid_progression: "raid_progression";
-  mythic_plus_scores_by_season: "mythic_plus_scores_by_season";
-  mythic_plus_ranks: "mythic_plus_ranks";
-  mythic_plus_recent_runs: "mythic_plus_recent_runs";
-  mythic_plus_best_runs: "mythic_plus_best_runs";
-  mythic_plus_alternate_runs: "mythic_plus_alternate_runs";
-  mythic_plus_highest_level_runs: "mythic_plus_highest_level_runs";
-  mythic_plus_weekly_highest_level_runs: "mythic_plus_weekly_highest_level_runs";
-  mythic_plus_previous_weekly_highest_level_runs: "mythic_plus_previous_weekly_highest_level_runs";
-  previous_mythic_plus_ranks: "previous_mythic_plus_ranks";
-  raid_achievement_meta: "raid_achievement_meta";
-  raid_achievement_curve: "raid_achievement_curve";
-};
+  export interface Affix {
+    id: number;
+    name: string;
+    description: string;
+    icon: string;
+    icon_url: string;
+    wowhead_url: string;
+  }
 
-export type OptionalCharacterProfilePayloadOptions = {
-  gear?: boolean;
-  talents?:
-    | boolean
-    | {
-        categorized: true;
-      };
-  guild?: boolean;
-  covenant?: boolean;
-  raid_progression?:
-    | boolean
-    | {
-        [
+  type MythicPlusRecentRunsType = MythicPlusRun[];
+  type MythicPlusBestRunsType = MythicPlusRun[];
+  type MythicPlusAlternateRunsType = MythicPlusRun[];
+  type MythicPlusHighestLevelRunsType = MythicPlusRun[];
+  type MythicPlusWeeklyHighestLevelRunsType = MythicPlusRun[];
+  type MythicPlusPreviousWeeklyHighestLevelRunsType = MythicPlusRun[];
+  type PreviousMythicPlusRanksType = MythicPlusRanksType;
+  // Both of these are unknown as nothing seemed to be returned.
+  type RaidMetaAchievementType = unknown;
+  type RaidAchievementCurveType = unknown;
+
+  export type OptionalCharacterProfilePayloadFields = {
+    gear?: GearType;
+    talents?: TalentType;
+    guild?: GuildType;
+    covenant?: CovenantType;
+    raid_progression?: RaidProgressionType;
+    mythic_plus_scores_by_season?: MythicPlusScoresBySeasonType;
+    mythic_plus_ranks?: MythicPlusRanksType;
+    mythic_plus_recent_runs?: MythicPlusRecentRunsType;
+    mythic_plus_best_runs?: MythicPlusBestRunsType;
+    mythic_plus_alternate_runs?: MythicPlusAlternateRunsType;
+    mythic_plus_highest_level_runs?: MythicPlusHighestLevelRunsType;
+    mythic_plus_weekly_highest_level_runs?: MythicPlusWeeklyHighestLevelRunsType;
+    mythic_plus_previous_weekly_highest_level_runs?: MythicPlusPreviousWeeklyHighestLevelRunsType;
+    previous_mythic_plus_ranks?: PreviousMythicPlusRanksType;
+    raid_achievement_meta?: RaidMetaAchievementType;
+    raid_achievement_curve?: RaidAchievementCurveType;
+  };
+
+  // This entire hash is just for the fact that talents does not match the output key.
+  // As far as I can tell every other key matches the key in the output.
+  type OutputKey = {
+    gear: "gear";
+    talents: "talentLoadout";
+    guild: "guild";
+    covenant: "covenant";
+    raid_progression: "raid_progression";
+    mythic_plus_scores_by_season: "mythic_plus_scores_by_season";
+    mythic_plus_ranks: "mythic_plus_ranks";
+    mythic_plus_recent_runs: "mythic_plus_recent_runs";
+    mythic_plus_best_runs: "mythic_plus_best_runs";
+    mythic_plus_alternate_runs: "mythic_plus_alternate_runs";
+    mythic_plus_highest_level_runs: "mythic_plus_highest_level_runs";
+    mythic_plus_weekly_highest_level_runs: "mythic_plus_weekly_highest_level_runs";
+    mythic_plus_previous_weekly_highest_level_runs: "mythic_plus_previous_weekly_highest_level_runs";
+    previous_mythic_plus_ranks: "previous_mythic_plus_ranks";
+    raid_achievement_meta: "raid_achievement_meta";
+    raid_achievement_curve: "raid_achievement_curve";
+  };
+
+  export type OptionalCharacterProfilePayloadOptions = {
+    gear?: boolean;
+    talents?:
+        | boolean
+        | {
+      categorized: true;
+    };
+    guild?: boolean;
+    covenant?: boolean;
+    raid_progression?:
+        | boolean
+        | {
+      [
           key:
-            | string
-            | number
-            | "current-expansion"
-            | "previous-expansion"
-            | "current-tier"
-            | "previous-tier"
-        ]: boolean;
-      };
-  mythic_plus_scores_by_season?:
-    | boolean
-    | {
-        [key: "current" | "previous" | `season-${string}` | string]: boolean;
-      };
-  mythic_plus_ranks?: boolean;
-  mythic_plus_recent_runs?: boolean;
-  mythic_plus_best_runs?:
-    | boolean
-    | {
-        all: boolean;
-      };
-  mythic_plus_alternate_runs?:
-    | boolean
-    | {
-        all: boolean;
-      };
-  mythic_plus_highest_level_runs?: boolean;
-  mythic_plus_weekly_highest_level_runs?: boolean;
-  mythic_plus_previous_weekly_highest_level_runs?: boolean;
-  previous_mythic_plus_ranks?: boolean;
-  raid_achievement_meta?: {
-    [key: `tier${number}`]: boolean;
+              | string
+              | number
+              | "current-expansion"
+              | "previous-expansion"
+              | "current-tier"
+              | "previous-tier"
+          ]: boolean;
+    };
+    mythic_plus_scores_by_season?:
+        | boolean
+        | {
+      [key: "current" | "previous" | `season-${string}` | string]: boolean;
+    };
+    mythic_plus_ranks?: boolean;
+    mythic_plus_recent_runs?: boolean;
+    mythic_plus_best_runs?:
+        | boolean
+        | {
+      all: boolean;
+    };
+    mythic_plus_alternate_runs?:
+        | boolean
+        | {
+      all: boolean;
+    };
+    mythic_plus_highest_level_runs?: boolean;
+    mythic_plus_weekly_highest_level_runs?: boolean;
+    mythic_plus_previous_weekly_highest_level_runs?: boolean;
+    previous_mythic_plus_ranks?: boolean;
+    raid_achievement_meta?: {
+      [key: `tier${number}`]: boolean;
+    };
+    raid_achievement_curve?: {
+      [key: `tier${number}`]: boolean;
+    };
   };
-  raid_achievement_curve?: {
-    [key: `tier${number}`]: boolean;
-  };
-};
 
-// Build up the output hash with only the keys that are requested.
-export type CharacterProfilePayload<
-  T extends OptionalCharacterProfilePayloadOptions
-> = CharacterPayloadBase & {
-  [key in keyof OptionalCharacterProfilePayloadFields as HasChildBool<
-    T[key]
-  > extends true
-    ? OutputKey[key]
-    : never]: OptionalCharacterProfilePayloadFields[key];
+  // Build up the output hash with only the keys that are requested.
+  export type CharacterProfilePayload<
+      T extends OptionalCharacterProfilePayloadOptions
+  > = CharacterPayloadBase & {
+    [key in keyof OptionalCharacterProfilePayloadFields as HasChildBool<
+        T[key]
+    > extends true
+        ? OutputKey[key]
+        : never]: OptionalCharacterProfilePayloadFields[key];
+  };
 };
 
 export class Character {
@@ -349,7 +352,7 @@ export class Character {
   }
 
   async getCharacterProfile<
-    T extends OptionalCharacterProfilePayloadOptions
+    T extends CharacterNS.OptionalCharacterProfilePayloadOptions
   >({
     region,
     realm,
@@ -360,7 +363,7 @@ export class Character {
     realm: string;
     name: string;
     fields?: T;
-  }): Promise<CharacterProfilePayload<T>> {
+  }): Promise<CharacterNS.CharacterProfilePayload<T>> {
     return this.client.get("/characters/profile", {
       params: {
         region,
@@ -372,7 +375,7 @@ export class Character {
   }
 
   async getCharacterProfiles<
-    T extends OptionalCharacterProfilePayloadOptions
+    T extends CharacterNS.OptionalCharacterProfilePayloadOptions
   >({
     characters,
   }: {
@@ -382,7 +385,7 @@ export class Character {
       name: string;
       fields?: T;
     }[];
-  }): Promise<CharacterProfilePayload<T>[]> {
+  }): Promise<CharacterNS.CharacterProfilePayload<T>[]> {
     return Promise.all(
       characters.map((character) => this.getCharacterProfile(character))
     );

--- a/app/lib/session.server.ts
+++ b/app/lib/session.server.ts
@@ -6,7 +6,7 @@ import {
 } from "react-router";
 import { db, Prisma, User } from "./db.server";
 
-const ADMINS = ["plohkoon", "captainfrogs"];
+const ADMINS = ["plohkoon", "captainfrogs", "pointysalad"];
 
 export const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({

--- a/app/routes/event/player/components/playerData.tsx
+++ b/app/routes/event/player/components/playerData.tsx
@@ -10,11 +10,9 @@ import { ClassDisplay } from "~/components/display/classDisplay";
 import { RoleDisplay } from "~/components/display/roleDisplay";
 import { CharacterName } from "~/components/display/characterName";
 import { TeamDataTable } from "../../show/components/teamDataTable";
+import { MythicData } from "~/lib/mythics";
 
 type Player = Route.ComponentProps["loaderData"]["player"];
-type Mythics = NonNullable<
-    Awaited<Route.ComponentProps["loaderData"]["mythicData"]>
->;
 
 export function PlayerData({
   player,
@@ -23,7 +21,7 @@ export function PlayerData({
 }: {
   player: Player;
   eventSlug: string;
-  mythicData: Mythics | null;
+  mythicData: MythicData[] | null;
 }) {
   return (
     <section className="grid grid-cols-[2fr_3fr] gap-4">

--- a/app/routes/event/player/components/playerData.tsx
+++ b/app/routes/event/player/components/playerData.tsx
@@ -12,13 +12,18 @@ import { CharacterName } from "~/components/display/characterName";
 import { TeamDataTable } from "../../show/components/teamDataTable";
 
 type Player = Route.ComponentProps["loaderData"]["player"];
+type Mythics = NonNullable<
+    Awaited<Route.ComponentProps["loaderData"]["mythicData"]>
+>;
 
 export function PlayerData({
   player,
   eventSlug,
+  mythicData
 }: {
   player: Player;
   eventSlug: string;
+  mythicData: Mythics | null;
 }) {
   return (
     <section className="grid grid-cols-[2fr_3fr] gap-4">
@@ -51,10 +56,8 @@ export function PlayerData({
         </TableBody>
       </Table>
       {player.team ? (
-        <TeamDataTable team={player.team} slug={eventSlug} />
-      ) : (
-        <div>No Team Assigned Yet</div>
-      )}
+          <TeamDataTable team={player.team} slug={eventSlug} mythicData={mythicData} />
+      ) : <div>No Team Assigned Yet</div>}
     </section>
   );
 }

--- a/app/routes/event/player/route.tsx
+++ b/app/routes/event/player/route.tsx
@@ -5,7 +5,7 @@ import { RaiderIOClient } from "~/lib/raiderIO";
 import { Route } from "./+types/route";
 import { CharacterData } from "./components/characterData";
 import { PlayerData } from "./components/playerData";
-import {getPlayersPromises, parseMythicDataPerTeam} from "~/lib/mythics";
+import { getPlayersPromises, parseMythicDataPerTeam } from "~/lib/mythics";
 
 export const loader = async ({ params: { id, slug } }: Route.LoaderArgs) => {
   const player = await db.player.findFirst({
@@ -43,7 +43,7 @@ export const loader = async ({ params: { id, slug } }: Route.LoaderArgs) => {
 
   const scoreTiers = client.mythicPlus.scoreTiers();
 
-    const playersPromises =  getPlayersPromises(player.team, client);
+  const playersPromises =  getPlayersPromises(player.team, client);
 
   return {
     player,
@@ -70,7 +70,7 @@ export const clientLoader = async ({
 clientLoader.hydrate = true;
 
 export default function PlayerShow({
-  loaderData: { player, playerData, scoreTiers, playersPromises, mythicData },
+  loaderData: { player, playerData, scoreTiers, mythicData },
   params: { slug },
 }: Route.ComponentProps) {
   return (

--- a/app/routes/event/show/components/teamDataTable.tsx
+++ b/app/routes/event/show/components/teamDataTable.tsx
@@ -103,7 +103,12 @@ const columns = [
   },
 ] satisfies ColumnDef<Team["players"][number]>[];
 
-function MythicsInfoOverview({ mythics }: { mythics: MythicData[] }) {
+function MythicsInfoOverview({ mythics }: { mythics: MythicData[] | null }) {
+
+    if(!mythics) {
+        return (<MissingMythicInfo></MissingMythicInfo>);
+    }
+
     const [bestMythics, bestMythicsScore] = useMemo(() => { return calculateBestMythicsAndTotalScore(mythics) }, [mythics]);
 
     const [bestSingleScore, mostUnderTime] = useMemo(() => { return calculateBestScoreAndBestUnderTime(mythics) }, [mythics]);

--- a/app/routes/event/show/components/teamDataTable.tsx
+++ b/app/routes/event/show/components/teamDataTable.tsx
@@ -156,6 +156,45 @@ function MythicsInfoOverview({ mythics }: { mythics: MythicData[] | null }) {
                     ))}
                 </div>
             </div>
+            <div>
+                <H4>Total Team Score</H4>
+                <div className="grid md:grid-cols-1 lg:grid-cols-2 3xl:grid-cols-4 gap-2 w-full">
+                    <div className="rounded-lg border border-neutral-100 grow">
+                        <div className="flex flex-col items-center space-around pb-2 pt-2 ps-1 pe-1">
+                            <span className="text-4xl font-semibold">{mythics.length}</span>
+                            <span className="text-md font-bold">Mythics Ran</span>
+                        </div>
+                    </div>
+                    <div className="rounded-lg border border-neutral-100 grow">
+                        <div className="flex flex-col items-center space-around pb-2 pt-2 ps-1 pe-1">
+                            <ScoreDisplay
+                                score={bestMythicsScore}
+                                className="text-4xl font-semibold"
+                            />
+                            <span className="text-md font-bold">Team Score</span>
+                        </div>
+                    </div>
+
+                    <div className="rounded-lg border border-neutral-100 grow">
+                        <div className="flex flex-col items-center space-around pb-2 pt-2 ps-1 pe-1">
+                            <ScoreDisplay
+                                score={bestSingleScore}
+                                individual
+                                className="text-4xl font-semibold"
+                            />
+                            <span className="text-md font-bold">Best Single Score</span>
+                        </div>
+                    </div>
+                    <div className="rounded-lg border border-neutral-100 grow">
+                        <div className="flex flex-col items-center space-around pb-2 pt-2 ps-1 pe-1">
+                            <span className="text-4xl font-semibold">
+                              {(mostUnderTime * 100).toFixed(2)}%
+                            </span>
+                            <span className="text-md font-bold">Best Under Par</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     );
 }

--- a/app/routes/event/show/components/teamDataTable.tsx
+++ b/app/routes/event/show/components/teamDataTable.tsx
@@ -20,10 +20,16 @@ import {
 import { H4 } from "~/components/display/headers";
 import { Button } from "~/components/ui/button";
 import { ArrowUpDown } from "lucide-react";
-import { useState } from "react";
-import { Link } from "react-router";
+import {Suspense, useMemo, useState} from "react";
+import {Await, Link} from "react-router";
+import {ScoreDisplay} from "~/components/display/scoreDisplay";
+import {CalculateBestMythicsAndTotalScore, CalculateBestScoreAndBestUnderTime} from "~/lib/mythics";
 
 type Team = Route.ComponentProps["loaderData"]["event"]["teams"][number];
+type Mythics = NonNullable<
+    Awaited<Route.ComponentProps["loaderData"]["parsedMythicDataArray"][number]>
+>;
+type MythicsPromise = Promise<Mythics | null>;
 
 const columns = [
   {
@@ -101,7 +107,68 @@ const columns = [
   },
 ] satisfies ColumnDef<Team["players"][number]>[];
 
-export function TeamDataTable({ team, slug }: { team: Team; slug: string }) {
+function MythicsInfoOverview({ mythics }: { mythics: Mythics }) {
+    const [bestMythics, bestMythicsScore] = useMemo(() => { return CalculateBestMythicsAndTotalScore(mythics) }, [mythics]);
+
+    const [bestSingleScore, mostUnderTime] = useMemo(() => { return CalculateBestScoreAndBestUnderTime(mythics) }, [mythics]);
+
+    return(
+        <div className="flex flex-col space-y-4">
+            <div>
+                <H4>Dungeons</H4>
+
+                <div className="grid md:grid-cols-1 lg:grid-cols-2 3xl:grid-cols-4 6xl:grid-cols-8 gap-2 w-full">
+                    {bestMythics.map((run) => (
+                        <div
+                            key={run.keystone_run_id}
+                            className="grow rounded-lg border-gray-100 border p-4 gap-2 bg-background/60 bg-(image:--bg-image) dark:bg-blend-darken bg-blend-lighten bg-linear-to-b bg-cover bg-no-repeat"
+                            style={{
+                                // @ts-expect-error: Variables are not typed
+                                "--bg-image": `url(${run.background_image_url})`,
+                            }}
+                        >
+                            <div className="flex flex-col items-center gap-y-2">
+                                <div className="flex flex-col justify-start text-3xl">
+                                    <ScoreDisplay
+                                        individual
+                                        score={run.score}
+                                        className=""
+                                    />
+                                </div>
+                                <div className="flex flex-row justify-evenly gap-4">
+                                    <p className="flex text-lg">
+                                        +{run.mythic_level}
+                                    </p>
+                                    <p className="flex text-lg">
+                                        {(
+                                            ((run.clear_time_ms - run.par_time_ms) / run.par_time_ms) *
+                                            100
+                                        ).toFixed(2)}
+                                        %
+                                    </p>
+                                </div>
+                                <p className="text-xl font-bold">
+                                    {run.short_name}
+                                </p>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function MissingMythicInfo() {
+    return (
+        <div className="flex flex-col gap-4">
+            <H4>Dungeons</H4>
+            <p>No Mythic data available.</p>
+        </div>
+    );
+}
+
+export function TeamDataTable({ team, slug, mythicData }: { team: Team; slug: string; mythicData: MythicsPromise }) {
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const table = useReactTable({
@@ -162,6 +229,17 @@ export function TeamDataTable({ team, slug }: { team: Team; slug: string }) {
           )}
         </TableBody>
       </Table>
+        <Suspense fallback={<div>loading...</div>}>
+            <Await resolve={mythicData} errorElement={<MissingMythicInfo />}>
+                {(mythicData) =>
+                    mythicData && mythicData.length > 0 ? (
+                        <MythicsInfoOverview mythics={mythicData} />
+                    ) : (
+                        <MissingMythicInfo />
+                    )
+                }
+            </Await>
+        </Suspense>
     </div>
   );
 }

--- a/app/routes/event/show/components/teamDataTable.tsx
+++ b/app/routes/event/show/components/teamDataTable.tsx
@@ -20,16 +20,12 @@ import {
 import { H4 } from "~/components/display/headers";
 import { Button } from "~/components/ui/button";
 import { ArrowUpDown } from "lucide-react";
-import {Suspense, useMemo, useState} from "react";
-import {Await, Link} from "react-router";
+import { useMemo, useState } from "react";
+import { Link } from "react-router";
 import {ScoreDisplay} from "~/components/display/scoreDisplay";
-import {CalculateBestMythicsAndTotalScore, CalculateBestScoreAndBestUnderTime} from "~/lib/mythics";
+import {calculateBestMythicsAndTotalScore, calculateBestScoreAndBestUnderTime, MythicData} from "~/lib/mythics";
 
 type Team = Route.ComponentProps["loaderData"]["event"]["teams"][number];
-type Mythics = NonNullable<
-    Awaited<Route.ComponentProps["loaderData"]["parsedMythicDataArray"][number]>
->;
-type MythicsPromise = Promise<Mythics | null>;
 
 const columns = [
   {
@@ -107,10 +103,10 @@ const columns = [
   },
 ] satisfies ColumnDef<Team["players"][number]>[];
 
-function MythicsInfoOverview({ mythics }: { mythics: Mythics }) {
-    const [bestMythics, bestMythicsScore] = useMemo(() => { return CalculateBestMythicsAndTotalScore(mythics) }, [mythics]);
+function MythicsInfoOverview({ mythics }: { mythics: MythicData[] }) {
+    const [bestMythics, bestMythicsScore] = useMemo(() => { return calculateBestMythicsAndTotalScore(mythics) }, [mythics]);
 
-    const [bestSingleScore, mostUnderTime] = useMemo(() => { return CalculateBestScoreAndBestUnderTime(mythics) }, [mythics]);
+    const [bestSingleScore, mostUnderTime] = useMemo(() => { return calculateBestScoreAndBestUnderTime(mythics) }, [mythics]);
 
     return(
         <div className="flex flex-col space-y-4">
@@ -168,7 +164,7 @@ function MissingMythicInfo() {
     );
 }
 
-export function TeamDataTable({ team, slug, mythicData }: { team: Team; slug: string; mythicData: MythicsPromise }) {
+export function TeamDataTable({ team, slug, mythicData }: { team: Team; slug: string; mythicData: MythicData[] | null }) {
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const table = useReactTable({
@@ -229,17 +225,7 @@ export function TeamDataTable({ team, slug, mythicData }: { team: Team; slug: st
           )}
         </TableBody>
       </Table>
-        <Suspense fallback={<div>loading...</div>}>
-            <Await resolve={mythicData} errorElement={<MissingMythicInfo />}>
-                {(mythicData) =>
-                    mythicData && mythicData.length > 0 ? (
-                        <MythicsInfoOverview mythics={mythicData} />
-                    ) : (
-                        <MissingMythicInfo />
-                    )
-                }
-            </Await>
-        </Suspense>
+        {mythicData && mythicData.length > 0 ? (<MythicsInfoOverview mythics={mythicData} />) : (<MissingMythicInfo />)}
     </div>
   );
 }

--- a/app/routes/event/show/route.tsx
+++ b/app/routes/event/show/route.tsx
@@ -9,7 +9,7 @@ import { PlayerDataTable } from "./components/playerDataTable";
 import { TeamDataTable } from "./components/teamDataTable";
 import {RaiderIOClient} from "~/lib/raiderIO";
 import { getPlayersPromises, parseMythicDataPerTeam, MythicData } from "~/lib/mythics"
-import {CharacterProfilePayload, OptionalCharacterProfilePayloadOptions} from "~/lib/raiderIO/characters";
+import { CharacterNS } from "~/lib/raiderIO/characters";
 
 export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
   const [event, isAdmin] = await Promise.all([
@@ -40,7 +40,7 @@ export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
   }
 
   const teams = organizeTeams(event.teams);
-  const eachTeamsPlayersPromises: (Promise<null> | Promise<CharacterProfilePayload<OptionalCharacterProfilePayloadOptions>>)[][] = [];
+  const eachTeamsPlayersPromises: (Promise<null> | Promise<CharacterNS.CharacterProfilePayload<CharacterNS.OptionalCharacterProfilePayloadOptions>>)[][] = [];
 
   const client = RaiderIOClient.getInstance();
 

--- a/app/routes/event/team/components/mythicInfo.tsx
+++ b/app/routes/event/team/components/mythicInfo.tsx
@@ -89,7 +89,7 @@ function MythicsInfoInternal({ mythics }: { mythics: Mythics }) {
 
         <H4>Dungeons</H4>
 
-        <div className="grid grid-cols-2 xl:grid-cols-3 gap-2">
+        <div className="grid sm:grid-cols-1 lg:grid-cols-2 2xl:grid-cols-4 gap-2">
           {bestMythics.map((run) => (
             <div
               key={run.keystone_run_id}

--- a/app/routes/event/team/route.tsx
+++ b/app/routes/event/team/route.tsx
@@ -5,7 +5,7 @@ import { Route } from "./+types/route";
 import { RaiderIOClient } from "~/lib/raiderIO";
 import { PlayerData } from "./components/playerData";
 import { MythicInfo } from "./components/mythicInfo";
-import {getPlayersPromises, parseMythicDataPerTeam} from "~/lib/mythics"
+import { getPlayersPromises, parseMythicDataPerTeam } from "~/lib/mythics"
 
 export const loader = async ({ params: { slug, id } }: Route.LoaderArgs) => {
   const team = await db.team.findFirst({

--- a/app/routes/event/team/route.tsx
+++ b/app/routes/event/team/route.tsx
@@ -1,11 +1,11 @@
-import { Await, Link, redirect } from "react-router";
+import { Link, redirect } from "react-router";
 import { H2 } from "~/components/display/headers";
 import { db } from "~/lib/db.server";
 import { Route } from "./+types/route";
 import { RaiderIOClient } from "~/lib/raiderIO";
-import { Suspense } from "react";
 import { PlayerData } from "./components/playerData";
 import { MythicInfo } from "./components/mythicInfo";
+import { ParseMythicDataPerTeam } from "~/lib/mythics"
 
 export const loader = async ({ params: { slug, id } }: Route.LoaderArgs) => {
   const team = await db.team.findFirst({
@@ -38,124 +38,130 @@ export const loader = async ({ params: { slug, id } }: Route.LoaderArgs) => {
       : Promise.resolve(null)
   );
 
+    const parsedMythicData =  await ParseMythicDataPerTeam(team.players, playersPromises);
+
   return {
     team,
     playersPromises,
-    allPlayersPromise: null,
-    mythicsPromise: null,
+    ...parsedMythicData,
   };
 };
 export const action = async ({}: Route.ActionArgs) => ({});
 
-export const clientLoader = async ({
-  serverLoader,
-}: Route.ClientLoaderArgs) => {
-  const serverRes = await serverLoader();
-
-  const players = serverRes.team.players;
-  const playersMap = new Map<string, (typeof players)[number]>();
-  players.forEach((p) => playersMap.set(p.id, p));
-
-  // Set these promises up in the client loader so they are stable in the react application.
-  const allPlayersPromise = Promise.allSettled(serverRes.playersPromises);
-  const mythicsPromise = allPlayersPromise.then((res) => {
-    // console.log("Mythics Promise", res);
-    if (!res) return res;
-
-    const succeededRes = res
-      .filter((r) => r.status === "fulfilled")
-      .map((r) => r.value);
-
-    type MythicType = NonNullable<
-      (typeof succeededRes)[number]
-    >["mythic_plus_best_runs"][number];
-
-    const mythicMap = new Map<number, MythicType>();
-    const participantMap = new Map<number, string[]>();
-    // console.log("DB Players", players);
-
-    succeededRes.forEach((player) => {
-      if (!player) return;
-      // We just want to resolve via the dbPlayer ID so we find and ensure we have that.
-      const dbPlayer = players.find(({ playerName, playerServer }) => {
-        // Stripe whitespace and replace lowercase to slugify everything for more accurate
-        // matching. This should be fine since names are not case sensitive.
-        const strip = (str: string | undefined | null) =>
-          str?.toLocaleLowerCase()?.replace(/\s/, "");
-
-        return (
-          strip(playerName) === strip(player.name) &&
-          strip(playerServer) === strip(player.realm)
-        );
-      });
-      // console.log("DB Player", dbPlayer, player.name, player.realm);
-      if (!dbPlayer) return;
-
-      const allMythics = [
-        ...(player.mythic_plus_best_runs ?? []),
-        ...(player.mythic_plus_alternate_runs ?? []),
-        ...(player.mythic_plus_highest_level_runs ?? []),
-        ...(player.mythic_plus_recent_runs ?? []),
-        ...(player.mythic_plus_previous_weekly_highest_level_runs ?? []),
-        ...(player.mythic_plus_weekly_highest_level_runs ?? []),
-      ];
-
-      allMythics.forEach((run) => {
-        mythicMap.set(run.keystone_run_id, run);
-
-        const participantsList = participantMap.get(run.keystone_run_id);
-
-        // Ensure this player is in the participant list
-        if (!participantsList) {
-          participantMap.set(run.keystone_run_id, [dbPlayer.id]);
-        } else if (participantsList.findIndex((id) => id === dbPlayer.id) < 0) {
-          participantsList.push(dbPlayer.id);
-        }
-      });
-    });
-
-    // console.log("Mythic Map", mythicMap);
-    // console.log("Participant Map", participantMap);
-
-    // A mythic counts if at least 4 players of the team are in it.
-    const mythics = Array.from(mythicMap.values())
-      .flatMap((m) => {
-        const participants = participantMap.get(m.keystone_run_id);
-
-        // If there were no participants or not enough participants this does not count as a key for this team.
-        if (!participants || participants.length < 4) {
-          return [];
-        }
-
-        return [
-          {
-            ...m,
-            participants: participants
-              .map((p) => playersMap.get(p))
-              .filter((p) => p !== undefined),
-          },
-        ];
-      })
-      .sort(
-        (mythicA, mythicB) =>
-          // First sort descending on the keystone level so higher keystones are at the top
-          mythicB.mythic_level - mythicA.mythic_level ||
-          // Next descending by score..
-          mythicB.score - mythicA.score ||
-          // Finally sort ascending within the score and mythic level category by string.
-          mythicA.short_name.localeCompare(mythicB.short_name)
-      );
-
-    return mythics;
-  });
-
-  return {
-    ...serverRes,
-    allPlayersPromise,
-    mythicsPromise,
-  };
-};
-clientLoader.hydrate = true;
+// export const clientLoader = async ({
+//   serverLoader,
+// }: Route.ClientLoaderArgs) => {
+//   const serverRes = await serverLoader();
+//
+//   const parsedMythicData =  await ParseMythicDataPerTeam(serverRes.team.players, serverRes.playersPromises);
+//
+//   return {
+//     ...serverRes,
+//     ...parsedMythicData,
+//   }
+  // const players = serverRes.team.players;
+  // const playersMap = new Map<string, (typeof players)[number]>();
+  // players.forEach((p) => playersMap.set(p.id, p));
+  //
+  // // Set these promises up in the client loader so they are stable in the react application.
+  // const allPlayersPromise = Promise.allSettled(serverRes.playersPromises);
+  // const mythicsPromise = allPlayersPromise.then((res) => { // console.log("Mythics Promise", res);
+  //   if (!res) return res;
+  //
+  //   const succeededRes = res
+  //       .filter((r: any) => r.status === "fulfilled")
+  //       .map((r: any) => r.value);
+  //
+  //   type MythicType = NonNullable<
+  //       (typeof succeededRes)[number]
+  //   >["mythic_plus_best_runs"][number];
+  //
+  //   const mythicMap = new Map<number, MythicType>();
+  //   const participantMap = new Map<number, string[]>();
+  //   // console.log("DB Players", players);
+  //
+  //   succeededRes.forEach((player: any) => {
+  //     if (!player) return;
+  //     // We just want to resolve via the dbPlayer ID so we find and ensure we have that.
+  //     const dbPlayer = players.find(({ playerName, playerServer }) => {
+  //       // Strip whitespace and replace lowercase to slugify everything for more accurate
+  //       // matching. This should be fine since names are not case-sensitive.
+  //       const strip = (str: string | undefined | null) =>
+  //           str?.toLocaleLowerCase()?.replace(/\s/, "");
+  //
+  //       return (
+  //           strip(playerName) === strip(player.name) &&
+  //           strip(playerServer) === strip(player.realm)
+  //       );
+  //     });
+  //     // console.log("DB Player", dbPlayer, player.name, player.realm);
+  //     if (!dbPlayer) return;
+  //
+  //     const allMythics = [
+  //       ...(player.mythic_plus_best_runs ?? []),
+  //       ...(player.mythic_plus_alternate_runs ?? []),
+  //       ...(player.mythic_plus_highest_level_runs ?? []),
+  //       ...(player.mythic_plus_recent_runs ?? []),
+  //       ...(player.mythic_plus_previous_weekly_highest_level_runs ?? []),
+  //       ...(player.mythic_plus_weekly_highest_level_runs ?? []),
+  //     ];
+  //
+  //     allMythics.forEach((run) => {
+  //       mythicMap.set(run.keystone_run_id, run);
+  //
+  //       const participantsList = participantMap.get(run.keystone_run_id);
+  //
+  //       // Ensure this player is in the participant list
+  //       if (!participantsList) {
+  //         participantMap.set(run.keystone_run_id, [dbPlayer.id]);
+  //       } else if (participantsList.findIndex((id) => id === dbPlayer.id) < 0) {
+  //         participantsList.push(dbPlayer.id);
+  //       }
+  //     });
+  //   });
+  //
+  //   // console.log("Mythic Map", mythicMap);
+  //   // console.log("Participant Map", participantMap);
+  //
+  //   // A mythic counts if at least 4 players of the team are in it.
+  //   const mythics = Array.from(mythicMap.values())
+  //       .flatMap((m) => {
+  //         const participants = participantMap.get(m.keystone_run_id);
+  //
+  //         // If there were no participants or not enough participants this does not count as a key for this team.
+  //         // if (!participants || participants.length < 4) {
+  //         //   return [];
+  //         // }
+  //
+  //         return [
+  //           {
+  //             ...m,
+  //             participants: participants
+  //                 .map((p) => playersMap.get(p))
+  //                 .filter((p) => p !== undefined),
+  //           },
+  //         ];
+  //       })
+  //       .sort(
+  //           (mythicA, mythicB) =>
+  //               // First sort descending on the keystone level so higher keystones are at the top.
+  //               mythicB.mythic_level - mythicA.mythic_level ||
+  //               // Next descending by score.
+  //               mythicB.score - mythicA.score ||
+  //               // Finally sort ascending within the score and mythic level category by string.
+  //               mythicA.short_name.localeCompare(mythicB.short_name)
+  //       );
+  //
+  //   return mythics;
+  // });
+  //
+  // return {
+  //   ...serverRes,
+  //   allPlayersPromise,
+  //   mythicsPromise,
+  // };
+// };
+// clientLoader.hydrate = true;
 
 export default function TeamShow({
   loaderData: { team, playersPromises, allPlayersPromise, mythicsPromise },

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -26,6 +26,9 @@
   --color-rare: #0070dd;
   --color-epic: #a335ee;
   --color-legendary: #ff8000;
+
+  --breakpoint-3xl: 120rem;
+  --breakpoint-6xl: 230rem;
 }
 
 @theme inline {


### PR DESCRIPTION
The changes included in this PR will show info on all team's best keys for each mythic dungeon on the event overview page. Furthermore, a couple of the functions that were to be duplicated were instead made into utility functions. These are in ```/lib/mythics.ts```

There are still two changes that I need to make. 

---

The first is to fix the following error that shows up in the console:

> Can't perform a React state update on a component that hasn't mounted yet. This indicates that you have a side-effect in your render function that asynchronously later calls tries to update the component. Move this work to useEffect instead.

This occurs when the user navigates to any specific team's overview page. I suspect the issue occurs because of the moving of the clientLoader code to a utility function so that it could be used in the Event Overview page as well. I don't know React / React Remix enough to understand why moving this code causes the error. And why this does not occur when navigating to the event overview page. The data still loads fine.

---

The second change is in the teams map lambda when creating each team's player table, in ```app/routes/event/show/route.tsx```. 

The parsedMythicData, which is an array of each team's mythic data, is currently indexed by using the index of the map function. This was done during testing since that was the easiest way to make sure what I was doing worked. Now I would like to instead combine the team object with the mythic data so that the teams array is still enumerated but the mythic data is correctly included and the array doesn't need to be indexed.

---

A further addition will be to also include the overall team's score, best single dungeon etc. to the Event Overview page as well.