### PR TITLE
Add augmented team scoring based on participant count

### DIFF
--- a/app/components/ui/mythicdisplay.tsx
+++ b/app/components/ui/mythicdisplay.tsx
@@ -1,10 +1,16 @@
 import { Link } from "react-router";
 import { ScoreDisplay } from "../display/scoreDisplay";
-import { CharacterNS } from "~/lib/raiderIO/characters";
+import type { MythicData } from "~/lib/mythics";
 
 type MythicProps = {
-  bestMythics: CharacterNS.MythicPlusRun[];
+  bestMythics: MythicData[];
 };
+
+function getParticipantBadgeClass(count: number): string {
+  if (count >= 5) return "bg-green-700/80";
+  if (count <= 3) return "bg-amber-700/80";
+  return "bg-black/60";
+}
 
 export default function MythicDisplay({ bestMythics }: MythicProps) {
   return (
@@ -34,6 +40,11 @@ export default function MythicDisplay({ bestMythics }: MythicProps) {
                     +{mythic.mythic_level} {mythic.short_name}
                   </h5>
                 </div>
+                <span
+                  className={`absolute top-0.5 right-0.5 z-20 text-[10px] font-semibold text-white px-1 py-0.5 rounded ${getParticipantBadgeClass(mythic.participants.length)}`}
+                >
+                  {mythic.participants.length}/5
+                </span>
               </div>
             </div>
           </Link>

--- a/app/lib/mythics.ts
+++ b/app/lib/mythics.ts
@@ -206,6 +206,53 @@ export function calculateBestMythicsAndTotalScore(mythics: MythicData[]) {
   return [Object.values(bestMythicsMap), totalScore] as const;
 }
 
+export const PARTICIPATION_MULTIPLIERS: Record<number, number> = {
+  3: 0.90,
+  4: 1.00,
+  5: 1.10,
+};
+
+export function getAugmentedScore(run: MythicData): number {
+  const multiplier = PARTICIPATION_MULTIPLIERS[run.participants.length] ?? 1.0;
+  return run.score * multiplier;
+}
+
+export type AugmentedMythicResult = {
+  bestMythics: MythicData[];
+  augmentedTotal: number;
+  augmentedScores: Map<number, number>;
+};
+
+export function calculateAugmentedBestMythicsAndTotalScore(
+  mythics: MythicData[]
+): AugmentedMythicResult {
+  const bestMythicsMap = {} as Record<string, MythicData>;
+  const augmentedScores = new Map<number, number>();
+
+  mythics.forEach((m: MythicData) => {
+    const augScore = getAugmentedScore(m);
+    augmentedScores.set(m.keystone_run_id, augScore);
+
+    const existing = bestMythicsMap[m.dungeon];
+    if (!existing) {
+      bestMythicsMap[m.dungeon] = m;
+    } else {
+      const existingAug = getAugmentedScore(existing);
+      if (augScore > existingAug) {
+        bestMythicsMap[m.dungeon] = m;
+      }
+    }
+  });
+
+  const bestMythics = Object.values(bestMythicsMap);
+  const augmentedTotal = bestMythics.reduce(
+    (acc, m) => acc + getAugmentedScore(m),
+    0
+  );
+
+  return { bestMythics, augmentedTotal, augmentedScores };
+}
+
 export function calculateBestScoreAndBestUnderTime(mythics: MythicData[]) {
   const bestSingleScore = mythics.reduce(
     (score: number, m: MythicData) => (score > m.score ? score : m.score),

--- a/app/routes/event/lists/components/teamDataTable.tsx
+++ b/app/routes/event/lists/components/teamDataTable.tsx
@@ -23,6 +23,7 @@ import {
   TableRow,
 } from "~/components/ui/table";
 import {
+  calculateAugmentedBestMythicsAndTotalScore,
   calculateBestMythicsAndTotalScore,
   calculateBestScoreAndBestUnderTime,
   MythicData,
@@ -107,13 +108,23 @@ const columns = [
   },
 ] satisfies ColumnDef<Team["players"][number]>[];
 
+function getParticipantBadgeClass(count: number): string {
+  if (count >= 5) return "bg-green-700/80";
+  if (count <= 3) return "bg-amber-700/80";
+  return "bg-black/60";
+}
+
 function MythicsInfoOverview({ mythics }: { mythics: MythicData[] | null }) {
   if (!mythics) {
     return <MissingMythicInfo></MissingMythicInfo>;
   }
 
-  const [bestMythics, bestMythicsScore] = useMemo(() => {
+  const [, bestMythicsScore] = useMemo(() => {
     return calculateBestMythicsAndTotalScore(mythics);
+  }, [mythics]);
+
+  const augmented = useMemo(() => {
+    return calculateAugmentedBestMythicsAndTotalScore(mythics);
   }, [mythics]);
 
   const [bestSingleScore, mostUnderTime] = useMemo(() => {
@@ -126,15 +137,20 @@ function MythicsInfoOverview({ mythics }: { mythics: MythicData[] | null }) {
         <H4>Dungeons</H4>
 
         <div className="grid md:grid-cols-1 lg:grid-cols-2 3xl:grid-cols-4 6xl:grid-cols-8 gap-2 w-full">
-          {bestMythics.map((run) => (
+          {augmented.bestMythics.map((run) => (
             <div
               key={run.keystone_run_id}
-              className="grow rounded-lg border-gray-100 border p-4 gap-2 bg-background/60 bg-(image:--bg-image) dark:bg-blend-darken bg-blend-lighten bg-linear-to-b bg-cover bg-no-repeat"
+              className="relative grow rounded-lg border-gray-100 border p-4 gap-2 bg-background/60 bg-(image:--bg-image) dark:bg-blend-darken bg-blend-lighten bg-linear-to-b bg-cover bg-no-repeat"
               style={{
                 // @ts-expect-error: Variables are not typed
                 "--bg-image": `url(${run.background_image_url})`,
               }}
             >
+              <span
+                className={`absolute top-1 right-1 text-[10px] font-semibold text-white px-1 py-0.5 rounded ${getParticipantBadgeClass(run.participants.length)}`}
+              >
+                {run.participants.length}/5
+              </span>
               <div className="flex flex-col items-center gap-y-2">
                 <div className="flex flex-col justify-start text-3xl">
                   <ScoreDisplay individual score={run.score} className="" />
@@ -168,10 +184,13 @@ function MythicsInfoOverview({ mythics }: { mythics: MythicData[] | null }) {
           <div className="rounded-lg border border-neutral-100 grow">
             <div className="flex flex-col items-center space-around pb-2 pt-2 ps-1 pe-1">
               <ScoreDisplay
-                score={bestMythicsScore}
+                score={augmented.augmentedTotal}
                 className="text-4xl font-semibold"
               />
               <span className="text-md font-bold">Team Score</span>
+              <span className="text-xs text-gray-500">
+                Raw: {bestMythicsScore.toFixed(1)}
+              </span>
             </div>
           </div>
 

--- a/app/routes/event/show/components/leaderboard.tsx
+++ b/app/routes/event/show/components/leaderboard.tsx
@@ -46,7 +46,7 @@ function LeaderBoardInternal({ zip }: { zip: MythicZip }) {
       if (sortBy === "single_score") {
         return b.bestSingleScore - a.bestSingleScore;
       } else if (sortBy === "team_score") {
-        return b.bestMythicsScore - a.bestMythicsScore;
+        return b.augmentedTotal - a.augmentedTotal;
       } else if (sortBy === "num_ran") {
         const aMythics = a.mythics?.length ?? 0;
         const bMythics = b.mythics?.length ?? 0;
@@ -153,10 +153,11 @@ function LeaderBoardInternal({ zip }: { zip: MythicZip }) {
                   {
                     team,
                     mythics,
-                    bestMythics,
                     bestMythicsScore,
                     mostUnderTime,
                     bestSingleScore,
+                    augmentedBestMythics,
+                    augmentedTotal,
                   },
                   index
                 ) => {
@@ -217,7 +218,10 @@ function LeaderBoardInternal({ zip }: { zip: MythicZip }) {
                                   Team Score
                                 </span>
                                 <span className="text-3xl font-bold drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]">
-                                  <ScoreDisplay score={bestMythicsScore} />
+                                  <ScoreDisplay score={augmentedTotal} />
+                                </span>
+                                <span className="text-xs text-black/60 dark:text-gray-500 mt-1">
+                                  Raw: {bestMythicsScore.toFixed(1)}
                                 </span>
                               </div>
                               <div className="bg-stone-300 dark:bg-black-two rounded-lg p-4 flex flex-col items-center justify-center">
@@ -245,7 +249,7 @@ function LeaderBoardInternal({ zip }: { zip: MythicZip }) {
                               </div>
                             </div>
                             {/* Mythic Display list component */}
-                            <MythicDisplay bestMythics={bestMythics} />
+                            <MythicDisplay bestMythics={augmentedBestMythics} />
                           </div>
                         </div>
                       </div>

--- a/app/routes/event/show/route.tsx
+++ b/app/routes/event/show/route.tsx
@@ -1,5 +1,6 @@
 import { db } from "~/lib/db.server";
 import {
+  calculateAugmentedBestMythicsAndTotalScore,
   calculateBestMythicsAndTotalScore,
   calculateBestScoreAndBestUnderTime,
   getPlayersPromises,
@@ -58,6 +59,9 @@ export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
           calculateBestMythicsAndTotalScore(mythicData ?? []);
         const [bestSingleScore, mostUnderTime] =
           calculateBestScoreAndBestUnderTime(mythicData ?? []);
+        const augmented = calculateAugmentedBestMythicsAndTotalScore(
+          mythicData ?? []
+        );
 
         return {
           team,
@@ -66,6 +70,9 @@ export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
           bestMythicsScore,
           bestSingleScore,
           mostUnderTime,
+          augmentedBestMythics: augmented.bestMythics,
+          augmentedTotal: augmented.augmentedTotal,
+          augmentedScores: Object.fromEntries(augmented.augmentedScores),
         };
       })
     ),

--- a/app/routes/event/team/components/mythicInfo.tsx
+++ b/app/routes/event/team/components/mythicInfo.tsx
@@ -11,10 +11,12 @@ import {
 function MythicsInfoInternal({
   mythics,
   bestMythicsScore,
+  augmentedTotal,
   bestMythics,
 }: {
   mythics: MythicData[];
   bestMythicsScore: number;
+  augmentedTotal: number;
   bestMythics: MythicData[];
 }) {
   if (!mythics) {
@@ -37,7 +39,10 @@ function MythicsInfoInternal({
         <Card className="bg-[#222222] border-[#333333] p-4 text-center">
           <p className="text-2xl font-bold text-green-500">
             <p className="text-sm text-gray-400">Team Score</p>
-            <ScoreDisplay score={bestMythicsScore} className="font-semibold" />
+            <ScoreDisplay score={augmentedTotal} className="font-semibold" />
+            <p className="text-xs text-gray-500 mt-1">
+              Raw: {bestMythicsScore.toFixed(1)}
+            </p>
           </p>
         </Card>
         <Card className="bg-[#222222] border-[#333333] p-4 text-center">
@@ -79,10 +84,12 @@ function MissingMythicInfo() {
 export function MythicInfo({
   mythics,
   bestMythicsScore,
+  augmentedTotal,
   bestMythics,
 }: {
   mythics: MythicData[] | null;
   bestMythicsScore: number;
+  augmentedTotal: number;
   bestMythics: MythicData[];
 }) {
   return (
@@ -91,6 +98,7 @@ export function MythicInfo({
         <MythicsInfoInternal
           mythics={mythics}
           bestMythicsScore={bestMythicsScore}
+          augmentedTotal={augmentedTotal}
           bestMythics={bestMythics}
         />
       ) : (

--- a/app/routes/event/team/components/teamMythicDisplay.tsx
+++ b/app/routes/event/team/components/teamMythicDisplay.tsx
@@ -1,24 +1,17 @@
 import { ScoreDisplay } from "~/components/display/scoreDisplay";
+import type { MythicData } from "~/lib/mythics";
 import { msToDuration } from "~/lib/time";
 import { getKeystoneUpgrade } from "../../player/components/mythicData";
 
-//gotta be a better way to do this?
-type Mythic = {
-  keystone_run_id: string | number;
-  icon_url: string;
-  short_name: string;
-  score: number;
-  dungeon: string;
-  background_image_url: string;
-  mythic_level: number;
-  clear_time_ms: number;
-  par_time_ms: number;
-  num_keystone_upgrades: number;
+type MythicProps = {
+  bestMythics: MythicData[];
 };
 
-type MythicProps = {
-  bestMythics: Mythic[];
-};
+function getParticipantBadgeClass(count: number): string {
+  if (count >= 5) return "bg-green-700/80";
+  if (count <= 3) return "bg-amber-700/80";
+  return "bg-black/60";
+}
 
 export default function TeamBestMythicDisplay({ bestMythics }: MythicProps) {
   return (
@@ -43,6 +36,12 @@ export default function TeamBestMythicDisplay({ bestMythics }: MythicProps) {
                 </span>
               </h3>
             </div>
+
+            <span
+              className={`absolute top-2 right-3 text-xs font-semibold text-white px-1.5 py-0.5 rounded ${getParticipantBadgeClass(run.participants.length)}`}
+            >
+              {run.participants.length}/5
+            </span>
 
             <div className="absolute bottom-2 left-3 right-3">
               <div className="flex justify-between items-center">

--- a/app/routes/event/team/route.tsx
+++ b/app/routes/event/team/route.tsx
@@ -4,6 +4,7 @@ import { Link, redirect } from "react-router";
 import { ScoreDisplay } from "~/components/display/scoreDisplay";
 import { db } from "~/lib/db.server";
 import {
+  calculateAugmentedBestMythicsAndTotalScore,
   calculateBestMythicsAndTotalScore,
   getPlayersPromises,
   parseMythicDataPerTeam,
@@ -64,6 +65,10 @@ export default function TeamShow({
   const [bestMythics, bestMythicsScore] = useMemo(() => {
     return calculateBestMythicsAndTotalScore(mythicData ?? []);
   }, [mythicData]);
+
+  const augmented = useMemo(() => {
+    return calculateAugmentedBestMythicsAndTotalScore(mythicData ?? []);
+  }, [mythicData]);
   return (
     <div className="space-y-6">
       <Link to={`/event/${slug}/`} className="bg-white p-2 rounded-md text-black">
@@ -122,11 +127,12 @@ export default function TeamShow({
             <MythicInfo
               mythics={mythicData}
               bestMythicsScore={bestMythicsScore}
-              bestMythics={bestMythics}
+              augmentedTotal={augmented.augmentedTotal}
+              bestMythics={augmented.bestMythics}
             />
             <div className="bg-black-two rounded-lg p-4 mt-6">
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                <TeamBestMythicDisplay bestMythics={bestMythics} />
+                <TeamBestMythicDisplay bestMythics={augmented.bestMythics} />
               </div>
             </div>
           </TabsContent>


### PR DESCRIPTION
## Summary
- Adds participation-based score multipliers (3 players: 0.90x, 4 players: 1.00x, 5 players: 1.10x) that reward teams running with more members
- Augmented score now determines best run per dungeon and team total used for leaderboard ranking; raw scores shown as secondary values
- Participant count badges (3/5, 4/5, 5/5) with color coding added to dungeon cards across leaderboard, team detail, and lists pages

## Test plan
- [ ] Run `npm run build` — confirm no type errors
- [ ] View leaderboard page — verify augmented score appears as primary, raw as secondary
- [ ] Verify sorting by Team Score uses augmented total
- [ ] Check dungeon cards show participant count badges with correct colors (green 5/5, neutral 4/5, amber 3/5)
- [ ] Visit team detail page — verify same augmented/raw display and badges
- [ ] Visit lists page — verify team overview shows augmented scores and badges
- [ ] Confirm a team with more 5-player runs ranks higher than one with equivalent raw scores but fewer participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)