### PR TITLE
Cache M+ runs in database with background sync

### DIFF
--- a/app/components/display/ilvlDisplay.tsx
+++ b/app/components/display/ilvlDisplay.tsx
@@ -12,7 +12,7 @@ export function IlvlDisplay<C extends React.ElementType = "span">({
 } & Omit<React.ComponentPropsWithoutRef<C>, "children">) {
   const Component = as || "span";
 
-  const tier = Math.max(Math.floor((ilvl - 619) / 12), 0);
+  const tier = Math.min(Math.max(Math.floor((ilvl - 100) / 14), 0), 4);
 
   return (
     <Component

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,7 +1,7 @@
 import "~/lib/init.server";
 
 import { isbot } from "isbot";
-import { renderToReadableStream } from "react-dom/server";
+import { renderToReadableStream } from "react-dom/server.browser";
 import { type HandleDataRequestFunction, ServerRouter } from "react-router";
 import type { AppLoadContext, EntryContext } from "react-router";
 

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,6 +1,5 @@
 import "~/lib/init.server";
 
-import { isbot } from "isbot";
 import { renderToReadableStream } from "react-dom/server.browser";
 import { type HandleDataRequestFunction, ServerRouter } from "react-router";
 import type { AppLoadContext, EntryContext } from "react-router";
@@ -13,7 +12,6 @@ export default async function handleRequest(
   _loadContext: AppLoadContext
 ) {
   let shellRendered = false;
-  const userAgent = request.headers.get("user-agent");
 
   const stream = await renderToReadableStream(
     <ServerRouter context={routerContext} url={request.url} />,
@@ -28,9 +26,7 @@ export default async function handleRequest(
   );
   shellRendered = true;
 
-  if (isbot(userAgent ?? "")) {
-    await stream.allReady;
-  }
+  await stream.allReady;
 
   responseHeaders.set("Content-Type", "text/html");
 

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,0 +1,47 @@
+import "~/lib/init.server";
+
+import { isbot } from "isbot";
+import { renderToReadableStream } from "react-dom/server";
+import { type HandleDataRequestFunction, ServerRouter } from "react-router";
+import type { AppLoadContext, EntryContext } from "react-router";
+
+export default async function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  _loadContext: AppLoadContext
+) {
+  let shellRendered = false;
+  const userAgent = request.headers.get("user-agent");
+
+  const stream = await renderToReadableStream(
+    <ServerRouter context={routerContext} url={request.url} />,
+    {
+      onError(error: unknown) {
+        responseStatusCode = 500;
+        if (shellRendered) {
+          console.error(error);
+        }
+      },
+    }
+  );
+  shellRendered = true;
+
+  if (isbot(userAgent ?? "")) {
+    await stream.allReady;
+  }
+
+  responseHeaders.set("Content-Type", "text/html");
+
+  return new Response(stream, {
+    headers: responseHeaders,
+    status: responseStatusCode,
+  });
+}
+
+export const handleDataRequest: HandleDataRequestFunction = async (
+  response
+) => {
+  return response;
+};

--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -4,6 +4,12 @@ const envSchema = z.object({
   RAIDERIO_API_KEY: z.string().optional(),
   TTL: z.coerce.number().default(1000 * 60 * 15),
   MAX_CACHE_SIZE: z.coerce.number().default(1000),
+  SYNC_INTERVAL_MS: z.coerce.number().default(1000 * 60 * 15),
+  SYNC_ENABLED: z
+    .string()
+    .default("true")
+    .transform((v) => v.toLowerCase() !== "false"),
+  SYNC_PLAYER_DELAY_MS: z.coerce.number().default(200),
 });
 
 const env = envSchema.parse(process.env);
@@ -11,5 +17,8 @@ const env = envSchema.parse(process.env);
 export const RAIDERIO_API_KEY = env.RAIDERIO_API_KEY;
 export const TTL = env.TTL;
 export const MAX_CACHE_SIZE = env.MAX_CACHE_SIZE;
+export const SYNC_INTERVAL_MS = env.SYNC_INTERVAL_MS;
+export const SYNC_ENABLED = env.SYNC_ENABLED;
+export const SYNC_PLAYER_DELAY_MS = env.SYNC_PLAYER_DELAY_MS;
 
 console.log(env);

--- a/app/lib/init.server.ts
+++ b/app/lib/init.server.ts
@@ -1,0 +1,3 @@
+import { startScheduler } from "~/lib/scheduler.server";
+
+startScheduler();

--- a/app/lib/runData.server.ts
+++ b/app/lib/runData.server.ts
@@ -73,6 +73,73 @@ export async function upsertRunsForPlayer(
 }
 
 /**
+ * Upserts a cached player profile from RaiderIO API data.
+ */
+export async function upsertPlayerProfile(
+  playerId: string,
+  profile: CharacterNS.CharacterPayloadBase & {
+    gear: { item_level_equipped: number; items: Record<string, unknown> };
+    mythic_plus_best_runs: CharacterNS.MythicPlusRun[];
+  }
+): Promise<void> {
+  const data = {
+    name: profile.name,
+    race: profile.race,
+    class: profile.class,
+    activeSpecName: profile.active_spec_name,
+    activeSpecRole: profile.active_spec_role,
+    faction: profile.faction,
+    region: profile.region,
+    realm: profile.realm,
+    thumbnailUrl: profile.thumbnail_url,
+    profileUrl: profile.profile_url,
+    itemLevelEquipped: profile.gear.item_level_equipped,
+    gearItems: JSON.stringify(profile.gear.items),
+    bestRuns: JSON.stringify(profile.mythic_plus_best_runs),
+  };
+
+  await db.cachedPlayerProfile.upsert({
+    where: { playerId },
+    create: { playerId, ...data },
+    update: data,
+  });
+}
+
+/**
+ * Gets a cached player profile from the database.
+ * Returns data in the same shape as a CharacterProfilePayload with gear + best runs.
+ */
+export async function getCachedPlayerProfile(playerId: string) {
+  const cached = await db.cachedPlayerProfile.findUnique({
+    where: { playerId },
+  });
+
+  if (!cached) return null;
+
+  return {
+    name: cached.name,
+    race: cached.race,
+    class: cached.class,
+    active_spec_name: cached.activeSpecName,
+    active_spec_role: cached.activeSpecRole,
+    gender: "",
+    faction: cached.faction,
+    achievement_points: 0,
+    thumbnail_url: cached.thumbnailUrl,
+    region: cached.region,
+    realm: cached.realm,
+    last_crawled_at: cached.updatedAt.toISOString(),
+    profile_url: cached.profileUrl,
+    profile_banner: "",
+    gear: {
+      item_level_equipped: cached.itemLevelEquipped,
+      items: JSON.parse(cached.gearItems),
+    },
+    mythic_plus_best_runs: JSON.parse(cached.bestRuns) as CharacterNS.MythicPlusRun[],
+  };
+}
+
+/**
  * Queries cached runs for all players on a team.
  * Groups by keystoneRunId, builds participant lists,
  * filters to runs with >= 3 team members, and sorts by level/score/name.

--- a/app/lib/runData.server.ts
+++ b/app/lib/runData.server.ts
@@ -1,0 +1,193 @@
+import type { CharacterNS } from "~/lib/raiderIO/characters";
+import type { DBPlayerType, DBTeamType, MythicData } from "~/lib/mythics";
+import {
+  getPlayersPromises,
+  parseMythicDataPerTeam,
+} from "~/lib/mythics";
+import { RaiderIOClient } from "~/lib/raiderIO";
+import { db } from "~/lib/db.server";
+
+/**
+ * Upserts MythicPlusRun rows and creates PlayerRun links for a given player.
+ * Used by the sync job.
+ */
+export async function upsertRunsForPlayer(
+  playerId: string,
+  runs: CharacterNS.MythicPlusRun[]
+): Promise<number> {
+  let upserted = 0;
+
+  for (const run of runs) {
+    const dbRun = await db.mythicPlusRun.upsert({
+      where: { keystoneRunId: run.keystone_run_id },
+      create: {
+        keystoneRunId: run.keystone_run_id,
+        dungeon: run.dungeon,
+        shortName: run.short_name,
+        mythicLevel: run.mythic_level,
+        completedAt: new Date(run.completed_at),
+        clearTimeMs: run.clear_time_ms,
+        parTimeMs: run.par_time_ms,
+        numKeystoneUpgrades: run.num_keystone_upgrades,
+        mapChallengeModeId: run.map_challenge_mode_id,
+        zoneId: run.zone_id,
+        zoneExpansionId: run.zone_expansion_id,
+        iconUrl: run.icon_url,
+        backgroundImageUrl: run.background_image_url,
+        score: run.score,
+        url: run.url,
+        affixes: JSON.stringify(run.affixes),
+      },
+      update: {
+        dungeon: run.dungeon,
+        shortName: run.short_name,
+        mythicLevel: run.mythic_level,
+        completedAt: new Date(run.completed_at),
+        clearTimeMs: run.clear_time_ms,
+        parTimeMs: run.par_time_ms,
+        numKeystoneUpgrades: run.num_keystone_upgrades,
+        mapChallengeModeId: run.map_challenge_mode_id,
+        zoneId: run.zone_id,
+        zoneExpansionId: run.zone_expansion_id,
+        iconUrl: run.icon_url,
+        backgroundImageUrl: run.background_image_url,
+        score: run.score,
+        url: run.url,
+        affixes: JSON.stringify(run.affixes),
+      },
+    });
+
+    // Create PlayerRun link (ignore if already exists)
+    await db.playerRun.upsert({
+      where: {
+        playerId_runId: { playerId, runId: dbRun.id },
+      },
+      create: { playerId, runId: dbRun.id },
+      update: {},
+    });
+
+    upserted++;
+  }
+
+  return upserted;
+}
+
+/**
+ * Queries cached runs for all players on a team.
+ * Groups by keystoneRunId, builds participant lists,
+ * filters to runs with >= 3 team members, and sorts by level/score/name.
+ * Returns MythicData[] (same shape as parseMythicDataPerTeam).
+ */
+export async function getCachedRunsForTeam(
+  team: DBTeamType,
+  options?: { after?: Date | null; before?: Date | null }
+): Promise<MythicData[]> {
+  const playerIds = team.players.map((p) => p.id);
+
+  // Build date filter for completedAt
+  const dateFilter: Record<string, Date> = {};
+  if (options?.after) dateFilter.gte = options.after;
+  if (options?.before) dateFilter.lte = options.before;
+
+  // Query all PlayerRun rows for this team's players, joined with the run data
+  const playerRuns = await db.playerRun.findMany({
+    where: {
+      playerId: { in: playerIds },
+      run: Object.keys(dateFilter).length > 0
+        ? { completedAt: dateFilter }
+        : undefined,
+    },
+    include: {
+      run: true,
+      player: {
+        include: { team: true },
+      },
+    },
+  });
+
+  // Group by keystoneRunId
+  const runMap = new Map<
+    number,
+    { run: (typeof playerRuns)[number]["run"]; participants: DBPlayerType[] }
+  >();
+
+  for (const pr of playerRuns) {
+    const keystoneRunId = pr.run.keystoneRunId;
+    const existing = runMap.get(keystoneRunId);
+
+    if (!existing) {
+      runMap.set(keystoneRunId, {
+        run: pr.run,
+        participants: [pr.player],
+      });
+    } else {
+      // Avoid duplicate participants
+      if (!existing.participants.some((p) => p.id === pr.player.id)) {
+        existing.participants.push(pr.player);
+      }
+    }
+  }
+
+  // Filter to runs with >= 3 team members and build MythicData[]
+  const mythics: MythicData[] = [];
+
+  for (const [, { run, participants }] of runMap) {
+    if (participants.length < 3) continue;
+
+    mythics.push({
+      dungeon: run.dungeon,
+      short_name: run.shortName,
+      mythic_level: run.mythicLevel,
+      completed_at: run.completedAt.toISOString(),
+      clear_time_ms: run.clearTimeMs,
+      keystone_run_id: run.keystoneRunId,
+      par_time_ms: run.parTimeMs,
+      num_keystone_upgrades: run.numKeystoneUpgrades,
+      map_challenge_mode_id: run.mapChallengeModeId,
+      zone_id: run.zoneId,
+      zone_expansion_id: run.zoneExpansionId,
+      icon_url: run.iconUrl,
+      background_image_url: run.backgroundImageUrl,
+      score: run.score,
+      url: run.url,
+      affixes: JSON.parse(run.affixes),
+      participants,
+    });
+  }
+
+  // Sort: mythic_level desc, score desc, short_name asc
+  mythics.sort(
+    (a, b) =>
+      b.mythic_level - a.mythic_level ||
+      b.score - a.score ||
+      a.short_name.localeCompare(b.short_name)
+  );
+
+  return mythics;
+}
+
+/**
+ * Gets mythic data for a team, trying the DB cache first then falling
+ * back to the live RaiderIO API if the cache is empty.
+ */
+export async function getMythicDataForTeam(
+  team: DBTeamType | null,
+  options?: { after?: Date | null; before?: Date | null }
+): Promise<MythicData[] | null> {
+  if (!team) return null;
+
+  // Try DB cache first
+  const cached = await getCachedRunsForTeam(team, options);
+  if (cached.length > 0) {
+    return cached;
+  }
+
+  // Fallback to live API
+  console.log(
+    `[getMythicDataForTeam] Cache empty for team "${team.name}", fetching from RaiderIO API`
+  );
+  const client = RaiderIOClient.getInstance();
+  const playersPromises = getPlayersPromises(team, client);
+  const mythicData = await parseMythicDataPerTeam(team, playersPromises);
+  return mythicData;
+}

--- a/app/lib/runData.server.ts
+++ b/app/lib/runData.server.ts
@@ -9,15 +9,23 @@ import { db } from "~/lib/db.server";
 
 /**
  * Upserts MythicPlusRun rows and creates PlayerRun links for a given player.
- * Used by the sync job.
+ * When dateRange is provided, only runs within the range are upserted.
  */
 export async function upsertRunsForPlayer(
   playerId: string,
-  runs: CharacterNS.MythicPlusRun[]
+  runs: CharacterNS.MythicPlusRun[],
+  dateRange?: { after?: Date | null; before?: Date | null }
 ): Promise<number> {
   let upserted = 0;
 
   for (const run of runs) {
+    // Skip runs outside the event date range
+    if (dateRange) {
+      const completedAt = new Date(run.completed_at);
+      if (dateRange.after && completedAt < dateRange.after) continue;
+      if (dateRange.before && completedAt > dateRange.before) continue;
+    }
+
     const dbRun = await db.mythicPlusRun.upsert({
       where: { keystoneRunId: run.keystone_run_id },
       create: {

--- a/app/lib/scheduler.server.ts
+++ b/app/lib/scheduler.server.ts
@@ -1,0 +1,40 @@
+import { SYNC_ENABLED, SYNC_INTERVAL_MS } from "~/lib/env.server";
+import { syncActiveEvents } from "~/lib/sync.server";
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+export function startScheduler(): void {
+  if (!SYNC_ENABLED) {
+    console.log("[Scheduler] Sync is disabled (SYNC_ENABLED=false)");
+    return;
+  }
+
+  if (intervalId) {
+    console.log("[Scheduler] Already running, skipping duplicate start");
+    return;
+  }
+
+  console.log(
+    `[Scheduler] Starting sync scheduler (interval: ${SYNC_INTERVAL_MS}ms)`
+  );
+
+  // Run immediately on startup
+  syncActiveEvents().catch((err) => {
+    console.error("[Scheduler] Initial sync failed:", err);
+  });
+
+  // Then run on interval
+  intervalId = setInterval(() => {
+    syncActiveEvents().catch((err) => {
+      console.error("[Scheduler] Scheduled sync failed:", err);
+    });
+  }, SYNC_INTERVAL_MS);
+}
+
+export function stopScheduler(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+    console.log("[Scheduler] Stopped");
+  }
+}

--- a/app/lib/sync.server.ts
+++ b/app/lib/sync.server.ts
@@ -1,0 +1,132 @@
+import { db } from "~/lib/db.server";
+import { RaiderIOClient } from "~/lib/raiderIO";
+import type { CharacterNS } from "~/lib/raiderIO/characters";
+import { upsertRunsForPlayer } from "~/lib/runData.server";
+import { SYNC_PLAYER_DELAY_MS } from "~/lib/env.server";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Syncs M+ run data for all active events.
+ * Fetches from RaiderIO API and persists to the database.
+ */
+export async function syncActiveEvents(): Promise<void> {
+  const activeEvents = await db.event.findMany({
+    where: { status: "ACTIVE" },
+    include: {
+      players: true,
+    },
+  });
+
+  if (activeEvents.length === 0) {
+    console.log("[Sync] No active events to sync");
+    return;
+  }
+
+  const client = RaiderIOClient.getInstance();
+
+  for (const event of activeEvents) {
+    const startedAt = new Date();
+    let playersSynced = 0;
+    let runsUpserted = 0;
+    let hasErrors = false;
+    let errorMessages: string[] = [];
+
+    // Create a RUNNING sync log entry
+    const syncLog = await db.syncLog.create({
+      data: {
+        eventId: event.id,
+        status: "RUNNING",
+        startedAt,
+      },
+    });
+
+    console.log(
+      `[Sync] Starting sync for event "${event.name}" (${event.players.length} players)`
+    );
+
+    for (const player of event.players) {
+      if (!player.playerName || !player.playerServer) {
+        continue;
+      }
+
+      try {
+        const profile = await client.character.getCharacterProfile({
+          region: "us",
+          realm: player.playerServer,
+          name: player.playerName,
+          fields: {
+            mythic_plus_best_runs: { all: true },
+            mythic_plus_alternate_runs: { all: true },
+            mythic_plus_highest_level_runs: true,
+            mythic_plus_recent_runs: true,
+            mythic_plus_previous_weekly_highest_level_runs: true,
+            mythic_plus_weekly_highest_level_runs: true,
+          },
+        });
+
+        const allRuns: CharacterNS.MythicPlusRun[] = [
+          ...(profile.mythic_plus_best_runs ?? []),
+          ...(profile.mythic_plus_alternate_runs ?? []),
+          ...(profile.mythic_plus_highest_level_runs ?? []),
+          ...(profile.mythic_plus_recent_runs ?? []),
+          ...(profile.mythic_plus_previous_weekly_highest_level_runs ?? []),
+          ...(profile.mythic_plus_weekly_highest_level_runs ?? []),
+        ];
+
+        // Deduplicate by keystone_run_id
+        const uniqueRuns = new Map<number, CharacterNS.MythicPlusRun>();
+        for (const run of allRuns) {
+          uniqueRuns.set(run.keystone_run_id, run);
+        }
+
+        const count = await upsertRunsForPlayer(
+          player.id,
+          Array.from(uniqueRuns.values())
+        );
+        runsUpserted += count;
+        playersSynced++;
+
+        console.log(
+          `[Sync]   ${player.playerName}-${player.playerServer}: ${count} runs upserted`
+        );
+      } catch (err) {
+        hasErrors = true;
+        const msg = `${player.playerName}-${player.playerServer}: ${err instanceof Error ? err.message : String(err)}`;
+        errorMessages.push(msg);
+        console.error(`[Sync]   Error for ${msg}`);
+      }
+
+      // Rate limit delay between player API calls
+      if (SYNC_PLAYER_DELAY_MS > 0) {
+        await delay(SYNC_PLAYER_DELAY_MS);
+      }
+    }
+
+    const completedAt = new Date();
+    const durationMs = completedAt.getTime() - startedAt.getTime();
+
+    await db.syncLog.update({
+      where: { id: syncLog.id },
+      data: {
+        status: hasErrors
+          ? playersSynced > 0
+            ? "PARTIAL"
+            : "FAILED"
+          : "COMPLETED",
+        playersSynced,
+        runsUpserted,
+        errorMessage:
+          errorMessages.length > 0 ? errorMessages.join("; ") : null,
+        completedAt,
+        durationMs,
+      },
+    });
+
+    console.log(
+      `[Sync] Completed sync for "${event.name}": ${playersSynced} players, ${runsUpserted} runs in ${durationMs}ms${hasErrors ? " (with errors)" : ""}`
+    );
+  }
+}

--- a/app/lib/sync.server.ts
+++ b/app/lib/sync.server.ts
@@ -9,15 +9,188 @@ function delay(ms: number): Promise<void> {
 }
 
 /**
+ * Syncs a single player: fetches profile + runs from RaiderIO,
+ * upserts runs (filtered by dateRange) and caches the profile.
+ */
+export async function syncPlayer(
+  player: { id: string; playerName: string; playerServer: string },
+  dateRange?: { after?: Date | null; before?: Date | null }
+): Promise<{ runsUpserted: number }> {
+  const client = RaiderIOClient.getInstance();
+
+  const profile = await client.character.getCharacterProfile({
+    region: "us",
+    realm: player.playerServer,
+    name: player.playerName,
+    fields: {
+      gear: true,
+      mythic_plus_best_runs: { all: true },
+      mythic_plus_alternate_runs: { all: true },
+      mythic_plus_highest_level_runs: true,
+      mythic_plus_recent_runs: true,
+      mythic_plus_previous_weekly_highest_level_runs: true,
+      mythic_plus_weekly_highest_level_runs: true,
+    },
+  });
+
+  const allRuns: CharacterNS.MythicPlusRun[] = [
+    ...(profile.mythic_plus_best_runs ?? []),
+    ...(profile.mythic_plus_alternate_runs ?? []),
+    ...(profile.mythic_plus_highest_level_runs ?? []),
+    ...(profile.mythic_plus_recent_runs ?? []),
+    ...(profile.mythic_plus_previous_weekly_highest_level_runs ?? []),
+    ...(profile.mythic_plus_weekly_highest_level_runs ?? []),
+  ];
+
+  // Deduplicate by keystone_run_id
+  const uniqueRuns = new Map<number, CharacterNS.MythicPlusRun>();
+  for (const run of allRuns) {
+    uniqueRuns.set(run.keystone_run_id, run);
+  }
+
+  const runsUpserted = await upsertRunsForPlayer(
+    player.id,
+    Array.from(uniqueRuns.values()),
+    dateRange
+  );
+
+  await upsertPlayerProfile(player.id, profile);
+
+  return { runsUpserted };
+}
+
+/**
+ * Syncs all players for a single event.
+ * Creates a SyncLog entry and returns when complete.
+ *
+ * If the event's end date has passed, the sync still runs (final sync)
+ * and then the event status is set to ENDED.
+ * Pass `force: true` (admin panel) to sync even if already ENDED.
+ */
+export async function syncEvent(
+  eventId: string,
+  options?: { force?: boolean }
+): Promise<void> {
+  const force = options?.force ?? false;
+
+  const event = await db.event.findUnique({
+    where: { id: eventId },
+    include: { players: true },
+  });
+
+  if (!event) {
+    throw new Error(`Event ${eventId} not found`);
+  }
+
+  const isExpired = event.endDate != null && event.endDate < new Date();
+
+  // If already ENDED and not forced, skip entirely
+  if (event.status === "ENDED" && !force) {
+    console.log(
+      `[Sync] Skipping ended event "${event.name}" (use force to override)`
+    );
+    return;
+  }
+
+  const startedAt = new Date();
+  let playersSynced = 0;
+  let runsUpserted = 0;
+  let hasErrors = false;
+  let errorMessages: string[] = [];
+
+  const syncLog = await db.syncLog.create({
+    data: {
+      eventId: event.id,
+      status: "RUNNING",
+      startedAt,
+    },
+  });
+
+  const dateRange = {
+    after: event.startDate,
+    before: event.endDate,
+  };
+
+  console.log(
+    `[Sync] Starting sync for event "${event.name}" (${event.players.length} players)`
+  );
+
+  for (const player of event.players) {
+    if (!player.playerName || !player.playerServer) {
+      continue;
+    }
+
+    try {
+      const result = await syncPlayer(
+        {
+          id: player.id,
+          playerName: player.playerName,
+          playerServer: player.playerServer,
+        },
+        dateRange
+      );
+      runsUpserted += result.runsUpserted;
+      playersSynced++;
+
+      console.log(
+        `[Sync]   ${player.playerName}-${player.playerServer}: ${result.runsUpserted} runs upserted, profile cached`
+      );
+    } catch (err) {
+      hasErrors = true;
+      const msg = `${player.playerName}-${player.playerServer}: ${err instanceof Error ? err.message : String(err)}`;
+      errorMessages.push(msg);
+      console.error(`[Sync]   Error for ${msg}`);
+    }
+
+    if (SYNC_PLAYER_DELAY_MS > 0) {
+      await delay(SYNC_PLAYER_DELAY_MS);
+    }
+  }
+
+  const completedAt = new Date();
+  const durationMs = completedAt.getTime() - startedAt.getTime();
+
+  await db.syncLog.update({
+    where: { id: syncLog.id },
+    data: {
+      status: hasErrors
+        ? playersSynced > 0
+          ? "PARTIAL"
+          : "FAILED"
+        : "COMPLETED",
+      playersSynced,
+      runsUpserted,
+      errorMessage:
+        errorMessages.length > 0 ? errorMessages.join("; ") : null,
+      completedAt,
+      durationMs,
+    },
+  });
+
+  console.log(
+    `[Sync] Completed sync for "${event.name}": ${playersSynced} players, ${runsUpserted} runs in ${durationMs}ms${hasErrors ? " (with errors)" : ""}`
+  );
+
+  // If the event has expired, mark it as ENDED after the final sync
+  if (isExpired && event.status === "ACTIVE") {
+    await db.event.update({
+      where: { id: event.id },
+      data: { status: "ENDED" },
+    });
+    console.log(
+      `[Sync] Event "${event.name}" has passed its end date, status set to ENDED`
+    );
+  }
+}
+
+/**
  * Syncs M+ run data for all active events.
  * Fetches from RaiderIO API and persists to the database.
  */
 export async function syncActiveEvents(): Promise<void> {
   const activeEvents = await db.event.findMany({
     where: { status: "ACTIVE" },
-    include: {
-      players: true,
-    },
+    select: { id: true },
   });
 
   if (activeEvents.length === 0) {
@@ -25,112 +198,7 @@ export async function syncActiveEvents(): Promise<void> {
     return;
   }
 
-  const client = RaiderIOClient.getInstance();
-
   for (const event of activeEvents) {
-    const startedAt = new Date();
-    let playersSynced = 0;
-    let runsUpserted = 0;
-    let hasErrors = false;
-    let errorMessages: string[] = [];
-
-    // Create a RUNNING sync log entry
-    const syncLog = await db.syncLog.create({
-      data: {
-        eventId: event.id,
-        status: "RUNNING",
-        startedAt,
-      },
-    });
-
-    console.log(
-      `[Sync] Starting sync for event "${event.name}" (${event.players.length} players)`
-    );
-
-    for (const player of event.players) {
-      if (!player.playerName || !player.playerServer) {
-        continue;
-      }
-
-      try {
-        const profile = await client.character.getCharacterProfile({
-          region: "us",
-          realm: player.playerServer,
-          name: player.playerName,
-          fields: {
-            gear: true,
-            mythic_plus_best_runs: { all: true },
-            mythic_plus_alternate_runs: { all: true },
-            mythic_plus_highest_level_runs: true,
-            mythic_plus_recent_runs: true,
-            mythic_plus_previous_weekly_highest_level_runs: true,
-            mythic_plus_weekly_highest_level_runs: true,
-          },
-        });
-
-        const allRuns: CharacterNS.MythicPlusRun[] = [
-          ...(profile.mythic_plus_best_runs ?? []),
-          ...(profile.mythic_plus_alternate_runs ?? []),
-          ...(profile.mythic_plus_highest_level_runs ?? []),
-          ...(profile.mythic_plus_recent_runs ?? []),
-          ...(profile.mythic_plus_previous_weekly_highest_level_runs ?? []),
-          ...(profile.mythic_plus_weekly_highest_level_runs ?? []),
-        ];
-
-        // Deduplicate by keystone_run_id
-        const uniqueRuns = new Map<number, CharacterNS.MythicPlusRun>();
-        for (const run of allRuns) {
-          uniqueRuns.set(run.keystone_run_id, run);
-        }
-
-        const count = await upsertRunsForPlayer(
-          player.id,
-          Array.from(uniqueRuns.values())
-        );
-        runsUpserted += count;
-        playersSynced++;
-
-        // Cache player profile data
-        await upsertPlayerProfile(player.id, profile);
-
-        console.log(
-          `[Sync]   ${player.playerName}-${player.playerServer}: ${count} runs upserted, profile cached`
-        );
-      } catch (err) {
-        hasErrors = true;
-        const msg = `${player.playerName}-${player.playerServer}: ${err instanceof Error ? err.message : String(err)}`;
-        errorMessages.push(msg);
-        console.error(`[Sync]   Error for ${msg}`);
-      }
-
-      // Rate limit delay between player API calls
-      if (SYNC_PLAYER_DELAY_MS > 0) {
-        await delay(SYNC_PLAYER_DELAY_MS);
-      }
-    }
-
-    const completedAt = new Date();
-    const durationMs = completedAt.getTime() - startedAt.getTime();
-
-    await db.syncLog.update({
-      where: { id: syncLog.id },
-      data: {
-        status: hasErrors
-          ? playersSynced > 0
-            ? "PARTIAL"
-            : "FAILED"
-          : "COMPLETED",
-        playersSynced,
-        runsUpserted,
-        errorMessage:
-          errorMessages.length > 0 ? errorMessages.join("; ") : null,
-        completedAt,
-        durationMs,
-      },
-    });
-
-    console.log(
-      `[Sync] Completed sync for "${event.name}": ${playersSynced} players, ${runsUpserted} runs in ${durationMs}ms${hasErrors ? " (with errors)" : ""}`
-    );
+    await syncEvent(event.id);
   }
 }

--- a/app/lib/sync.server.ts
+++ b/app/lib/sync.server.ts
@@ -1,7 +1,7 @@
 import { db } from "~/lib/db.server";
 import { RaiderIOClient } from "~/lib/raiderIO";
 import type { CharacterNS } from "~/lib/raiderIO/characters";
-import { upsertRunsForPlayer } from "~/lib/runData.server";
+import { upsertRunsForPlayer, upsertPlayerProfile } from "~/lib/runData.server";
 import { SYNC_PLAYER_DELAY_MS } from "~/lib/env.server";
 
 function delay(ms: number): Promise<void> {
@@ -58,6 +58,7 @@ export async function syncActiveEvents(): Promise<void> {
           realm: player.playerServer,
           name: player.playerName,
           fields: {
+            gear: true,
             mythic_plus_best_runs: { all: true },
             mythic_plus_alternate_runs: { all: true },
             mythic_plus_highest_level_runs: true,
@@ -89,8 +90,11 @@ export async function syncActiveEvents(): Promise<void> {
         runsUpserted += count;
         playersSynced++;
 
+        // Cache player profile data
+        await upsertPlayerProfile(player.id, profile);
+
         console.log(
-          `[Sync]   ${player.playerName}-${player.playerServer}: ${count} runs upserted`
+          `[Sync]   ${player.playerName}-${player.playerServer}: ${count} runs upserted, profile cached`
         );
       } catch (err) {
         hasErrors = true;

--- a/app/routes/event/_layout.tsx
+++ b/app/routes/event/_layout.tsx
@@ -17,7 +17,12 @@ export const loader = async ({
     where: { slug },
   });
 
-  return { isAdmin, name: event?.name ?? "unknown event" };
+  return {
+    isAdmin,
+    name: event?.name ?? "unknown event",
+    startDate: event?.startDate ?? null,
+    endDate: event?.endDate ?? null,
+  };
 };
 
 const schema = z
@@ -26,8 +31,25 @@ const schema = z
   })
   .transform((v) => v.edit);
 
+function formatDate(date: string | Date) {
+  return new Date(date).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatDateRange(startDate: string | Date | null, endDate: string | Date | null) {
+  if (startDate && endDate) {
+    return `${formatDate(startDate)} – ${formatDate(endDate)}`;
+  }
+  if (startDate) return formatDate(startDate);
+  if (endDate) return formatDate(endDate);
+  return null;
+}
+
 export default function EventLayout({
-  loaderData: { isAdmin, name },
+  loaderData: { isAdmin, name, startDate, endDate },
   params: { slug },
 }: Route.ComponentProps) {
   const edit = useMatches().reduce(
@@ -39,6 +61,11 @@ export default function EventLayout({
     <main>
       <div>
         <H2 className="text-6xl mx-4 text-center mt-10">{name}</H2>
+        {formatDateRange(startDate, endDate) && (
+          <p className="text-center text-muted-foreground mt-2">
+            {formatDateRange(startDate, endDate)}
+          </p>
+        )}
       </div>
         <div className="flex-1 flex flex-row space-x-4 justify-center items-center px-4 my-4">
           <Button asChild>

--- a/app/routes/event/components/eventCard.tsx
+++ b/app/routes/event/components/eventCard.tsx
@@ -2,18 +2,24 @@ import { Calendar, Image } from "lucide-react";
 import { Link } from "react-router";
 import { Card, CardContent } from "~/components/ui/card";
 
-// simple function to format date for card
 function formatDate(date: string | Date) {
-    return new Date(date).toLocaleDateString("en-CA", {
+    return new Date(date).toLocaleDateString("en-US", {
         year: "numeric",
-        month: "long",
+        month: "short",
         day: "numeric",
     });
+}
 
-};
+function formatDateRange(event: any) {
+    if (event.startDate && event.endDate) {
+        return `${formatDate(event.startDate)} – ${formatDate(event.endDate)}`;
+    }
+    if (event.startDate) return formatDate(event.startDate);
+    if (event.endDate) return formatDate(event.endDate);
+    return formatDate(event.createdAt);
+}
 
 export default function EventCard({ event }: { event: any }) {
-    console.log(event);
     return (
         <Link to={`/event/${event.slug}`}>
             <Card className="group overflow-hidden border-border bg-card transition-all hover:border-primary/50 hover:shadow-lg">
@@ -43,7 +49,7 @@ export default function EventCard({ event }: { event: any }) {
                                 <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
                                     <div className="flex items-center gap-1.5">
                                         <Calendar className="h-4 w-4" />
-                                        <span>{formatDate(event.createdAt)}</span>
+                                        <span>{formatDateRange(event)}</span>
                                     </div>
                                 </div>
                             </div>

--- a/app/routes/event/edit.tsx
+++ b/app/routes/event/edit.tsx
@@ -28,11 +28,12 @@ import { SpecInput } from "~/components/inputs/specInput";
 import { CTextInput } from "~/components/inputs/textInput";
 import { TableBody } from "~/components/ui/table";
 import { db } from "~/lib/db.server";
-import { EventStatus, Role } from "~/lib/prisma";
+import { EventStatus, Role, SyncLog } from "~/lib/prisma";
 import { AppSession } from "~/lib/session.server";
+import { syncEvent, syncPlayer } from "~/lib/sync.server";
 import { Route } from "./lists/+types/route";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
-import { ChevronDown, ChevronUp, Dices, Pencil, Settings, Trash2, UserPlus, Users } from "lucide-react";
+import { ChevronDown, ChevronUp, Dices, Loader2, Pencil, RefreshCw, Settings, Trash2, UserPlus, Users } from "lucide-react";
 import { sort } from "fast-sort";
 
 const ROLE_ORDER: Record<string, number> = {
@@ -80,11 +81,16 @@ const updateEventSchema = z.object({
   action: z.literal("updateEvent"),
 });
 
+const forceSyncSchema = z.object({
+  action: z.literal("forceSync"),
+});
+
 const schema = z.union([
   addPlayerSchema,
   updatePlayerSchema,
   deletePlayerSchema,
   updateEventSchema,
+  forceSyncSchema,
 ]);
 
 export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
@@ -110,7 +116,12 @@ export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
     throw new Response("Not Found", { status: 404 });
   }
 
-  return { event };
+  const lastSync = await db.syncLog.findFirst({
+    where: { eventId: event.id },
+    orderBy: { startedAt: "desc" },
+  });
+
+  return { event, lastSync };
 }
 
 export async function action({ request, params: { slug } }: Route.ActionArgs) {
@@ -170,16 +181,30 @@ export async function action({ request, params: { slug } }: Route.ActionArgs) {
       teamId = team.id;
     }
 
-    await db.player.create({
+    const newPlayer = await db.player.create({
       data: {
         nickname: value.nickname,
         main: value.main,
         assignedRole: value.assignedRole,
         spec: value.spec,
+        playerName: value.playerName,
+        playerServer: value.playerServer,
         teamId,
         eventId: event.id,
       },
     });
+
+    // Immediately sync the new player in the background
+    if (value.playerName && value.playerServer) {
+      syncPlayer(
+        { id: newPlayer.id, playerName: value.playerName, playerServer: value.playerServer },
+        { after: event.startDate, before: event.endDate }
+      ).then(({ runsUpserted }) => {
+        console.log(`[EditSync] Synced new player ${value.playerName}: ${runsUpserted} runs`);
+      }).catch((err) => {
+        console.error(`[EditSync] Failed to sync ${value.playerName}:`, err);
+      });
+    }
   } else if (value.action === "update") {
     const existingPlayer = await db.player.findUnique({
       where: {
@@ -244,6 +269,20 @@ export async function action({ request, params: { slug } }: Route.ActionArgs) {
       },
     });
 
+    // Sync if playerName/playerServer was added or changed
+    const nameChanged = value.playerName !== existingPlayer.playerName
+      || value.playerServer !== existingPlayer.playerServer;
+    if (nameChanged && value.playerName && value.playerServer) {
+      syncPlayer(
+        { id: existingPlayer.id, playerName: value.playerName, playerServer: value.playerServer },
+        { after: event.startDate, before: event.endDate }
+      ).then(({ runsUpserted }) => {
+        console.log(`[EditSync] Synced updated player ${value.playerName}: ${runsUpserted} runs`);
+      }).catch((err) => {
+        console.error(`[EditSync] Failed to sync ${value.playerName}:`, err);
+      });
+    }
+
     // Cleanup leftover teams if all players are removed.
     if (
       existingPlayer?.teamId &&
@@ -275,9 +314,103 @@ export async function action({ request, params: { slug } }: Route.ActionArgs) {
       where: { id: event.id },
       data: updateData,
     });
+  } else if (value.action === "forceSync") {
+    await syncEvent(event.id, { force: true });
   }
 
   return res.reply();
+}
+
+function SyncCard({ lastSync }: { lastSync: SyncLog | null }) {
+  const fetcher = useFetcher();
+  const isSyncing = fetcher.state !== "idle";
+
+  const statusColors: Record<string, string> = {
+    COMPLETED: "text-green-400",
+    RUNNING: "text-yellow-400",
+    PARTIAL: "text-yellow-400",
+    FAILED: "text-red-400",
+  };
+
+  return (
+    <Card className="mb-8 border-border/50 bg-card/50 backdrop-blur">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <RefreshCw className="h-5 w-5" />
+            </div>
+            <div>
+              <CardTitle className="text-lg">Data Sync</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Sync player profiles and M+ runs from RaiderIO
+              </p>
+            </div>
+          </div>
+          <fetcher.Form method="post">
+            <Button
+              type="submit"
+              name="action"
+              value="forceSync"
+              disabled={isSyncing}
+            >
+              {isSyncing ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Syncing...
+                </>
+              ) : (
+                <>
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  Force Sync
+                </>
+              )}
+            </Button>
+          </fetcher.Form>
+        </div>
+      </CardHeader>
+      {lastSync && (
+        <CardContent>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 text-sm">
+            <div>
+              <p className="text-muted-foreground">Status</p>
+              <p className={`font-medium ${statusColors[lastSync.status] ?? ""}`}>
+                {lastSync.status}
+              </p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Last Synced</p>
+              <p className="font-medium">
+                {lastSync.completedAt
+                  ? new Date(lastSync.completedAt).toLocaleString()
+                  : lastSync.startedAt
+                    ? new Date(lastSync.startedAt).toLocaleString()
+                    : "N/A"}
+              </p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Players Synced</p>
+              <p className="font-medium">{lastSync.playersSynced}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Runs Upserted</p>
+              <p className="font-medium">{lastSync.runsUpserted}</p>
+            </div>
+          </div>
+          {lastSync.durationMs != null && (
+            <p className="text-xs text-muted-foreground mt-3">
+              Completed in {(lastSync.durationMs / 1000).toFixed(1)}s
+            </p>
+          )}
+          {lastSync.errorMessage && (
+            <p className="text-xs text-red-400 mt-2 truncate" title={lastSync.errorMessage}>
+              Errors: {lastSync.errorMessage}
+            </p>
+          )}
+        </CardContent>
+      )}
+    </Card>
+  );
 }
 
 function EditPlayerRow({
@@ -435,9 +568,11 @@ export const handle = {
 };
 
 export default function EventEdit({
-  loaderData: { event },
+  loaderData,
   params: { slug },
 }: Route.ComponentProps) {
+  const { event } = loaderData;
+  const lastSync = (loaderData as any).lastSync as SyncLog | null;
   const [addPlayerForm, addPlayerFields] = useForm({
     id: "add-player",
     onValidate({ formData }) {
@@ -555,6 +690,8 @@ export default function EventEdit({
             </CardContent>
           )}
         </Card>
+
+        <SyncCard lastSync={lastSync} />
 
         <Card className="mb-8 border-border/50 bg-card/50 backdrop-blur">
           <CardHeader>

--- a/app/routes/event/edit.tsx
+++ b/app/routes/event/edit.tsx
@@ -28,11 +28,11 @@ import { SpecInput } from "~/components/inputs/specInput";
 import { CTextInput } from "~/components/inputs/textInput";
 import { TableBody } from "~/components/ui/table";
 import { db } from "~/lib/db.server";
-import { Role } from "~/lib/prisma";
+import { EventStatus, Role } from "~/lib/prisma";
 import { AppSession } from "~/lib/session.server";
 import { Route } from "./lists/+types/route";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
-import { ChevronDown, ChevronUp, Dices, Pencil, Trash2, UserPlus, Users } from "lucide-react";
+import { ChevronDown, ChevronUp, Dices, Pencil, Settings, Trash2, UserPlus, Users } from "lucide-react";
 import { sort } from "fast-sort";
 
 const ROLE_ORDER: Record<string, number> = {
@@ -73,10 +73,18 @@ const deletePlayerSchema = z.object({
   action: z.literal("delete"),
 });
 
+const updateEventSchema = z.object({
+  startDate: z.string().optional().transform((v) => (v ? new Date(v) : undefined)),
+  endDate: z.string().optional().transform((v) => (v ? new Date(v) : undefined)),
+  status: z.nativeEnum(EventStatus).optional(),
+  action: z.literal("updateEvent"),
+});
+
 const schema = z.union([
   addPlayerSchema,
   updatePlayerSchema,
   deletePlayerSchema,
+  updateEventSchema,
 ]);
 
 export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
@@ -257,6 +265,16 @@ export async function action({ request, params: { slug } }: Route.ActionArgs) {
     ) {
       await db.team.delete({ where: { id: player.teamId } });
     }
+  } else if (value.action === "updateEvent") {
+    const updateData: Record<string, unknown> = {};
+    if (value.startDate !== undefined) updateData.startDate = value.startDate;
+    if (value.endDate !== undefined) updateData.endDate = value.endDate;
+    if (value.status !== undefined) updateData.status = value.status;
+
+    await db.event.update({
+      where: { id: event.id },
+      data: updateData,
+    });
   }
 
   return res.reply();
@@ -426,6 +444,7 @@ export default function EventEdit({
       return parseWithZod(formData, { schema: addPlayerSchema });
     },
   });
+  const [isSettingsExpanded, setIsSettingsExpanded] = useState(false);
   const [isPlayerExpanded, setIsPlayersExpanded] = useState(true);
   const [isRosterExpanded, setIsRosterExpanded] = useState(true);
   const [sortBy, setSortBy] = useState<"team" | "role">("team");
@@ -454,10 +473,89 @@ export default function EventEdit({
 
     return players;
   }
+  const eventFetcher = useFetcher();
+
+  const formatDateForInput = (date: Date | string | null | undefined) => {
+    if (!date) return "";
+    const d = typeof date === "string" ? new Date(date) : date;
+    return d.toISOString().slice(0, 16);
+  };
+
   return (
     <>
       <Outlet />
       <main className="container mx-auto px-8 py-8 max-w-32xl">
+        <Card className="mb-8 border-border/50 bg-card/50 backdrop-blur">
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <Settings className="h-5 w-5" />
+                </div>
+                <div>
+                  <CardTitle className="text-lg">Event Settings</CardTitle>
+                  <p className="text-sm text-muted-foreground">
+                    {event.name} &mdash; Status: {event.status ?? "ACTIVE"}
+                  </p>
+                </div>
+              </div>
+              <Button variant="ghost" size="icon" className="shrink-0 cursor-pointer" onClick={() => setIsSettingsExpanded(!isSettingsExpanded)}>
+                {isSettingsExpanded ? (
+                  <ChevronUp className="h-5 w-5" />
+                ) : (
+                  <ChevronDown className="h-5 w-5" />
+                )}
+              </Button>
+            </div>
+          </CardHeader>
+          {isSettingsExpanded && (
+            <CardContent>
+              <eventFetcher.Form method="post">
+                <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                  <div className="space-y-2">
+                    <label htmlFor="startDate" className="text-sm font-medium">Start Date</label>
+                    <input
+                      type="datetime-local"
+                      id="startDate"
+                      name="startDate"
+                      defaultValue={formatDateForInput(event.startDate)}
+                      className="flex h-10 w-full rounded-md border border-input bg-input px-3 py-2 text-sm"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="endDate" className="text-sm font-medium">End Date</label>
+                    <input
+                      type="datetime-local"
+                      id="endDate"
+                      name="endDate"
+                      defaultValue={formatDateForInput(event.endDate)}
+                      className="flex h-10 w-full rounded-md border border-input bg-input px-3 py-2 text-sm"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="status" className="text-sm font-medium">Status</label>
+                    <select
+                      id="status"
+                      name="status"
+                      defaultValue={event.status ?? "ACTIVE"}
+                      className="flex h-10 w-full rounded-md border border-input bg-input px-3 py-2 text-sm"
+                    >
+                      <option value="ACTIVE">Active</option>
+                      <option value="ENDED">Ended</option>
+                      <option value="ARCHIVED">Archived</option>
+                    </select>
+                  </div>
+                </div>
+                <div className="mt-6 flex justify-start">
+                  <Button type="submit" name="action" value="updateEvent">
+                    Save Event Settings
+                  </Button>
+                </div>
+              </eventFetcher.Form>
+            </CardContent>
+          )}
+        </Card>
+
         <Card className="mb-8 border-border/50 bg-card/50 backdrop-blur">
           <CardHeader>
             <div className="flex items-center justify-between">

--- a/app/routes/event/lists/route.tsx
+++ b/app/routes/event/lists/route.tsx
@@ -2,13 +2,8 @@ import { Link } from "react-router";
 import { H2, H3 } from "~/components/display/headers";
 import { Button } from "~/components/ui/button";
 import { db } from "~/lib/db.server";
-import {
-  getPlayersPromises,
-  MythicData,
-  parseMythicDataPerTeam,
-} from "~/lib/mythics";
-import { RaiderIOClient } from "~/lib/raiderIO";
 import { AppSession } from "~/lib/session.server";
+import { getMythicDataForTeam } from "~/lib/runData.server";
 import { organizeTeams } from "~/lib/teams";
 import { Route } from "./+types/route";
 import { PlayerDataTable } from "./components/playerDataTable";
@@ -21,7 +16,9 @@ export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
       include: {
         teams: {
           include: {
-            players: true,
+            players: {
+              include: { team: true },
+            },
           },
         },
         players: {
@@ -43,43 +40,23 @@ export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
   }
 
   const teams = organizeTeams(event.teams);
-  const client = RaiderIOClient.getInstance();
-  const eachTeamsPlayersPromises = teams.map((team) =>
-    getPlayersPromises(team, client)
+
+  const parsedMythicDataArray = await Promise.all(
+    teams.map((team) =>
+      getMythicDataForTeam(team, {
+        after: event.startDate,
+        before: event.endDate,
+      })
+    )
   );
 
   return {
     event,
     teams,
     isAdmin,
-    eachTeamsPlayersPromises,
-    parsedMythicDataArray: null,
-  };
-}
-
-export const clientLoader = async ({
-  serverLoader,
-}: Route.ClientLoaderArgs) => {
-  const serverRes = await serverLoader();
-
-  const parsedMythicDataArray: (MythicData[] | null)[] = [];
-  let counter: number = 0;
-
-  for (const team of serverRes.teams) {
-    const mythicData = await parseMythicDataPerTeam(
-      team,
-      serverRes.eachTeamsPlayersPromises[counter]
-    );
-    parsedMythicDataArray.push(mythicData);
-    ++counter;
-  }
-
-  return {
-    ...serverRes,
     parsedMythicDataArray,
   };
-};
-clientLoader.hydrate = true;
+}
 
 export default function Event({
   loaderData: { event, teams, isAdmin, parsedMythicDataArray },

--- a/app/routes/event/player/components/characterData.tsx
+++ b/app/routes/event/player/components/characterData.tsx
@@ -7,11 +7,9 @@ import TeamData from "./teamData";
 
 type Player = Route.ComponentProps["loaderData"]["player"];
 type PlayerData = NonNullable<Route.ComponentProps["loaderData"]["playerData"]>;
-type ScoreTiers = NonNullable<Route.ComponentProps["loaderData"]["scoreTiers"]>;
 
 function CharacterDataInternal(
   props: PlayerData & {
-    scoreTiers: ScoreTiers;
     player: Player;
     mythicData: MythicData[] | null;
   }
@@ -55,13 +53,11 @@ function MissingCharacterData() {
 
 export function CharacterData({
   playerData,
-  scoreTiers,
   player,
   eventSlug,
   mythicData,
 }: {
   playerData: PlayerData | null;
-  scoreTiers: ScoreTiers | null;
   player: Player;
   eventSlug: string;
   mythicData: MythicData[] | null;
@@ -71,7 +67,6 @@ export function CharacterData({
   return (
     <CharacterDataInternal
       {...playerData}
-      scoreTiers={scoreTiers ?? []}
       player={player}
       mythicData={mythicData}
     />

--- a/app/routes/event/player/components/characterData.tsx
+++ b/app/routes/event/player/components/characterData.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from "react";
-import { Await } from "react-router";
 import { MythicData } from "~/lib/mythics";
 import type { Route } from "../+types/route";
 import CharacterProfile from "./characterProfile";
@@ -8,15 +6,8 @@ import PlayerMythicData from "./mythicData";
 import TeamData from "./teamData";
 
 type Player = Route.ComponentProps["loaderData"]["player"];
-
-type PlayerData = NonNullable<
-  Awaited<Route.ComponentProps["loaderData"]["playerData"]>
->;
-type ScoreTiers = NonNullable<
-  Awaited<Route.ComponentProps["loaderData"]["scoreTiers"]>
->;
-type PlayerDataPromise = Promise<PlayerData | null>;
-type ScoreTiersPromise = Promise<ScoreTiers | null>;
+type PlayerData = NonNullable<Route.ComponentProps["loaderData"]["playerData"]>;
+type ScoreTiers = NonNullable<Route.ComponentProps["loaderData"]["scoreTiers"]>;
 
 function CharacterDataInternal(
   props: PlayerData & {
@@ -69,31 +60,20 @@ export function CharacterData({
   eventSlug,
   mythicData,
 }: {
-  playerData: PlayerDataPromise;
-  scoreTiers: ScoreTiersPromise;
+  playerData: PlayerData | null;
+  scoreTiers: ScoreTiers | null;
   player: Player;
   eventSlug: string;
   mythicData: MythicData[] | null;
 }) {
+  if (!playerData) return <MissingCharacterData />;
+
   return (
-    <Suspense fallback={<div>Loading..</div>}>
-      <Await
-        resolve={Promise.all([playerData, scoreTiers])}
-        errorElement={<MissingCharacterData />}
-      >
-        {([data, tiers]) =>
-          data ? (
-            <CharacterDataInternal
-              {...data}
-              scoreTiers={tiers ?? []}
-              player={player}
-              mythicData={mythicData}
-            />
-          ) : (
-            <MissingCharacterData />
-          )
-        }
-      </Await>
-    </Suspense>
+    <CharacterDataInternal
+      {...playerData}
+      scoreTiers={scoreTiers ?? []}
+      player={player}
+      mythicData={mythicData}
+    />
   );
 }

--- a/app/routes/event/player/components/equipmentData.tsx
+++ b/app/routes/event/player/components/equipmentData.tsx
@@ -52,7 +52,7 @@ export default function EquipmentData({ objectKeys, gear }: any) {
 
         {/* Always show content on desktop, respect isExpanded on mobile */}
         <div
-          className="transition-all duration-300 ease-in-out lg:block data-[expanded=true]:block data-[expanded=false]:hidden"
+          className="transition-all duration-300 ease-in-out hidden data-[expanded=true]:block lg:block"
           data-expanded={isExpanded}
         >
           <CardContent className="pt-6">
@@ -69,17 +69,17 @@ export default function EquipmentData({ objectKeys, gear }: any) {
                     <div className="flex items-center p-3 text-white dark:text-black rounded-md bg-neutral-400 dark:bg-[#555555] hover:bg-[#666666] transition-colors">
                       <div className="flex-shrink-0 mr-3 relative">
                         <div className="w-10 h-10 rounded border border-[#A0E7A0] overflow-hidden bg-black">
-                          {/* This works but we don't wanna get in trouble lmao */}
-                          {/* <img src={`https://cdn.raiderio.net/images/wow/icons/large/${item.icon}.jpg`} /> */}
-
-                          {/* <img
-                          src={item.icon || "/placeholder.svg"}
-                          alt={item.name}
-                          width={40}
-                          height={40}
-                          className="object-cover"
-                        /> */}
-                          <Sword className="mx-auto text-white" height={36} />
+                          {item.icon ? (
+                            <img
+                              src={`https://wow.zamimg.com/images/wow/icons/large/${item.icon}.jpg`}
+                              alt={item.name}
+                              width={40}
+                              height={40}
+                              className="object-cover"
+                            />
+                          ) : (
+                            <Sword className="mx-auto text-white" height={36} />
+                          )}
                         </div>
                       </div>
                       <div className="flex-1 min-w-0">

--- a/app/routes/event/player/components/mythicData.tsx
+++ b/app/routes/event/player/components/mythicData.tsx
@@ -50,7 +50,7 @@ export default function PlayerMythicData({
 
         {/* Always show content on desktop, respect isExpanded on mobile */}
         <div
-          className="transition-all duration-300 ease-in-out lg:block data-[expanded=true]:block data-[expanded=false]:hidden"
+          className="transition-all duration-300 ease-in-out hidden data-[expanded=true]:block lg:block"
           data-expanded={isExpanded}
         >
           <CardContent className="pt-6 transition-all duration-300 ease-in-out">

--- a/app/routes/event/player/components/teamData.tsx
+++ b/app/routes/event/player/components/teamData.tsx
@@ -63,7 +63,7 @@ export default function TeamData({
 
       {/* Always show content on desktop, respect isExpanded on mobile */}
       <div
-        className="transition-all duration-300 ease-in-out lg:block data-[expanded=true]:block data-[expanded=false]:hidden"
+        className="transition-all duration-300 ease-in-out hidden data-[expanded=true]:block lg:block"
         data-expanded={isExpanded}
       >
         <div className="flex">
@@ -78,14 +78,17 @@ export default function TeamData({
           >
             <div className="flex-shrink-0 mr-4 relative">
               <div className="w-12 h-12 rounded-full overflow-hidden border-2 border-[#FF6B6B] bg-[#444444]">
-                <User width={45} height={50} className="object-cover" />
-                {/* <img
-                  src={""}
-                  alt={member.name}
-                  width={50}
-                  height={50}
-                  className="object-cover"
-                /> */}
+                {member.cachedProfile?.thumbnailUrl ? (
+                  <img
+                    src={member.cachedProfile.thumbnailUrl}
+                    alt={member.playerName ?? ""}
+                    width={50}
+                    height={50}
+                    className="object-cover"
+                  />
+                ) : (
+                  <User width={45} height={50} className="object-cover" />
+                )}
               </div>
               <div className="absolute -bottom-1 -right-1 p-1 rounded-full bg-[#444444]">
                 {getRoleIcon(member.assignedRole ?? "")}

--- a/app/routes/event/player/route.tsx
+++ b/app/routes/event/player/route.tsx
@@ -1,6 +1,6 @@
 import { Link, redirect } from "react-router";
 import { db } from "~/lib/db.server";
-import { getPlayersPromises, parseMythicDataPerTeam } from "~/lib/mythics";
+import { getMythicDataForTeam } from "~/lib/runData.server";
 import { RaiderIOClient } from "~/lib/raiderIO";
 import { Route } from "./+types/route";
 import { CharacterData } from "./components/characterData";
@@ -14,7 +14,9 @@ export const loader = async ({ params: { id, slug } }: Route.LoaderArgs) => {
       event: true,
       team: {
         include: {
-          players: true,
+          players: {
+            include: { team: true },
+          },
         },
       },
     },
@@ -41,34 +43,19 @@ export const loader = async ({ params: { id, slug } }: Route.LoaderArgs) => {
 
   const scoreTiers = client.mythicPlus.scoreTiers();
 
-  const playersPromises = getPlayersPromises(player.team, client);
+  const mythicData = await getMythicDataForTeam(player.team, {
+    after: player.event?.startDate,
+    before: player.event?.endDate,
+  });
 
   return {
     player,
     playerData,
     scoreTiers,
-    playersPromises,
-    mythicData: null,
-  };
-};
-export const action = async ({}: Route.ActionArgs) => {};
-
-export const clientLoader = async ({
-  serverLoader,
-}: Route.ClientLoaderArgs) => {
-  const serverRes = await serverLoader();
-
-  const mythicData = await parseMythicDataPerTeam(
-    serverRes.player.team,
-    serverRes.playersPromises
-  );
-
-  return {
-    ...serverRes,
     mythicData,
   };
 };
-clientLoader.hydrate = true;
+export const action = async ({}: Route.ActionArgs) => {};
 
 export default function PlayerShow({
   loaderData: { player, playerData, scoreTiers, mythicData },

--- a/app/routes/event/player/route.tsx
+++ b/app/routes/event/player/route.tsx
@@ -28,20 +28,19 @@ export const loader = async ({ params: { id, slug } }: Route.LoaderArgs) => {
 
   const client = RaiderIOClient.getInstance();
 
-  let playerData =
-    player.playerServer && player.playerName
-      ? client.character.getCharacterProfile({
-          region: "us",
-          realm: player.playerServer,
-          name: player.playerName,
-          fields: {
-            gear: true,
-            mythic_plus_best_runs: true,
-          },
-        })
-      : Promise.resolve(null);
+  const playerData = player.playerServer && player.playerName
+    ? await client.character.getCharacterProfile({
+        region: "us",
+        realm: player.playerServer,
+        name: player.playerName,
+        fields: {
+          gear: true,
+          mythic_plus_best_runs: true,
+        },
+      })
+    : null;
 
-  const scoreTiers = client.mythicPlus.scoreTiers();
+  const scoreTiers = await client.mythicPlus.scoreTiers();
 
   const mythicData = await getMythicDataForTeam(player.team, {
     after: player.event?.startDate,

--- a/app/routes/event/player/route.tsx
+++ b/app/routes/event/player/route.tsx
@@ -1,6 +1,6 @@
 import { Link, redirect } from "react-router";
 import { db } from "~/lib/db.server";
-import { getMythicDataForTeam } from "~/lib/runData.server";
+import { getCachedPlayerProfile, getMythicDataForTeam } from "~/lib/runData.server";
 import { RaiderIOClient } from "~/lib/raiderIO";
 import { Route } from "./+types/route";
 import { CharacterData } from "./components/characterData";
@@ -15,7 +15,7 @@ export const loader = async ({ params: { id, slug } }: Route.LoaderArgs) => {
       team: {
         include: {
           players: {
-            include: { team: true },
+            include: { team: true, cachedProfile: true },
           },
         },
       },
@@ -26,21 +26,24 @@ export const loader = async ({ params: { id, slug } }: Route.LoaderArgs) => {
     throw redirect(`/event/${slug}`);
   }
 
-  const client = RaiderIOClient.getInstance();
+  // Try cached profile first, fall back to live API
+  let playerData = await getCachedPlayerProfile(player.id);
 
-  const playerData = player.playerServer && player.playerName
-    ? await client.character.getCharacterProfile({
-        region: "us",
-        realm: player.playerServer,
-        name: player.playerName,
-        fields: {
-          gear: true,
-          mythic_plus_best_runs: true,
-        },
-      })
-    : null;
-
-  const scoreTiers = await client.mythicPlus.scoreTiers();
+  if (!playerData && player.playerServer && player.playerName) {
+    console.log(
+      `[PlayerLoader] Cache empty for "${player.playerName}", fetching from RaiderIO API`
+    );
+    const client = RaiderIOClient.getInstance();
+    playerData = await client.character.getCharacterProfile({
+      region: "us",
+      realm: player.playerServer,
+      name: player.playerName,
+      fields: {
+        gear: true,
+        mythic_plus_best_runs: true,
+      },
+    });
+  }
 
   const mythicData = await getMythicDataForTeam(player.team, {
     after: player.event?.startDate,
@@ -50,14 +53,13 @@ export const loader = async ({ params: { id, slug } }: Route.LoaderArgs) => {
   return {
     player,
     playerData,
-    scoreTiers,
     mythicData,
   };
 };
 export const action = async ({}: Route.ActionArgs) => {};
 
 export default function PlayerShow({
-  loaderData: { player, playerData, scoreTiers, mythicData },
+  loaderData: { player, playerData, mythicData },
   params: { slug },
 }: Route.ComponentProps) {
   return (
@@ -69,7 +71,6 @@ export default function PlayerShow({
       <div className="">
         <CharacterData
           playerData={playerData}
-          scoreTiers={scoreTiers}
           player={player}
           eventSlug={slug}
           mythicData={mythicData}

--- a/app/routes/event/show/components/leaderboard.tsx
+++ b/app/routes/event/show/components/leaderboard.tsx
@@ -6,8 +6,8 @@ import {
 } from "@radix-ui/react-dropdown-menu";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@radix-ui/react-tabs";
 import { ChevronDown, Users } from "lucide-react";
-import { Suspense, useMemo, useState } from "react";
-import { Await, Link, useParams } from "react-router";
+import { useMemo, useState } from "react";
+import { Link, useParams } from "react-router";
 import { PlayerShortDisplay } from "~/components/display/playerShortDisplay";
 import { ScoreDisplay } from "~/components/display/scoreDisplay";
 import { Button } from "~/components/ui/button";
@@ -15,10 +15,7 @@ import MythicDisplay from "~/components/ui/mythicdisplay";
 import { getGreenTextClass } from "~/lib/mythics";
 import { Route } from "../+types/route";
 
-type MythicZip = NonNullable<
-  Awaited<Route.ComponentProps["loaderData"]["mythicTeamZip"]>
->;
-type MythicZipPromise = Promise<MythicZip | null>;
+type MythicZip = Route.ComponentProps["loaderData"]["mythicTeamZip"];
 
 type Sort = "single_score" | "team_score" | "num_ran" | "under_par" | null;
 
@@ -265,26 +262,12 @@ function LeaderBoardInternal({ zip }: { zip: MythicZip }) {
   );
 }
 
-function LeaderBoardLoading() {
-  return <div className="text-center">Loading...</div>;
-}
+export function LeaderBoard({ zip }: { zip: MythicZip }) {
+  if (!zip || zip.length === 0) {
+    return <div className="text-center">No Mythic Data Found</div>;
+  }
 
-function LeaderBoardMissing() {
-  return <div className="text-center">No Mythic Data Found</div>;
-}
-
-export function LeaderBoard({ zip }: { zip: MythicZipPromise | null }) {
-  return (
-    <Suspense fallback={<LeaderBoardLoading />}>
-      <Await resolve={zip}>
-        {(mythicZip) => {
-          if (!mythicZip) return <LeaderBoardMissing />;
-
-          return <LeaderBoardInternal zip={mythicZip} />;
-        }}
-      </Await>
-    </Suspense>
-  );
+  return <LeaderBoardInternal zip={zip} />;
 }
 
 // old code for reference rn

--- a/app/routes/event/show/route.tsx
+++ b/app/routes/event/show/route.tsx
@@ -3,10 +3,8 @@ import {
   calculateAugmentedBestMythicsAndTotalScore,
   calculateBestMythicsAndTotalScore,
   calculateBestScoreAndBestUnderTime,
-  getPlayersPromises,
-  parseMythicDataPerTeam,
 } from "~/lib/mythics";
-import { RaiderIOClient } from "~/lib/raiderIO";
+import { getMythicDataForTeam } from "~/lib/runData.server";
 import { AppSession } from "~/lib/session.server";
 import { organizeTeams } from "~/lib/teams";
 import { Route } from "./+types/route";
@@ -19,7 +17,9 @@ export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
       include: {
         teams: {
           include: {
-            players: true,
+            players: {
+              include: { team: true },
+            },
           },
         },
         players: {
@@ -41,19 +41,14 @@ export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
   }
 
   const teams = organizeTeams(event.teams);
-  const client = RaiderIOClient.getInstance();
-
-  const eachTeamsPlayersPromises = teams.map((team) =>
-    getPlayersPromises(team, client)
-  );
 
   return {
     mythicTeamZip: Promise.all(
-      teams.map(async (team, i) => {
-        const mythicData = await parseMythicDataPerTeam(
-          team,
-          eachTeamsPlayersPromises[i]
-        );
+      teams.map(async (team) => {
+        const mythicData = await getMythicDataForTeam(team, {
+          after: event.startDate,
+          before: event.endDate,
+        });
 
         const [bestMythics, bestMythicsScore] =
           calculateBestMythicsAndTotalScore(mythicData ?? []);

--- a/app/routes/event/show/route.tsx
+++ b/app/routes/event/show/route.tsx
@@ -42,9 +42,8 @@ export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
 
   const teams = organizeTeams(event.teams);
 
-  return {
-    mythicTeamZip: Promise.all(
-      teams.map(async (team) => {
+  const mythicTeamZip = await Promise.all(
+    teams.map(async (team) => {
         const mythicData = await getMythicDataForTeam(team, {
           after: event.startDate,
           before: event.endDate,
@@ -69,9 +68,10 @@ export async function loader({ request, params: { slug } }: Route.LoaderArgs) {
           augmentedTotal: augmented.augmentedTotal,
           augmentedScores: Object.fromEntries(augmented.augmentedScores),
         };
-      })
-    ),
-  };
+    })
+  );
+
+  return { mythicTeamZip };
 }
 
 export default function Event({

--- a/app/routes/event/stats/route.tsx
+++ b/app/routes/event/stats/route.tsx
@@ -2,9 +2,8 @@ import { Link } from "react-router";
 import { Route } from "./+types/route";
 import { H2 } from "~/components/display/headers";
 import { db } from "~/lib/db.server";
-import { RaiderIOClient } from "~/lib/raiderIO";
 import { CharacterNS } from "~/lib/raiderIO/characters";
-import { getPlayersPromises, parseMythicDataPerTeam } from "~/lib/mythics";
+import { getMythicDataForTeam } from "~/lib/runData.server";
 import {
   Table,
   TableBody,
@@ -20,7 +19,9 @@ export async function loader({ params: { slug } }: Route.LoaderArgs) {
     include: {
       teams: {
         include: {
-          players: true,
+          players: {
+            include: { team: true },
+          },
         },
       },
     },
@@ -30,14 +31,16 @@ export async function loader({ params: { slug } }: Route.LoaderArgs) {
     throw new Response("Not Found", { status: 404 });
   }
 
-  const client = RaiderIOClient.getInstance();
-  const teamPromises = await Promise.all(
+  const teamResults = await Promise.all(
     event.teams.map((team) =>
-      parseMythicDataPerTeam(team, getPlayersPromises(team, client))
+      getMythicDataForTeam(team, {
+        after: event.startDate,
+        before: event.endDate,
+      })
     )
   );
 
-  const allDungeons = teamPromises.flatMap((team) => (team ? team : []));
+  const allDungeons = teamResults.flatMap((team) => (team ? team : []));
 
   const allDungeonsByDungeon = allDungeons.reduce((acc, dungeon) => {
     if (!acc.has(dungeon.dungeon)) {

--- a/app/routes/event/team/components/playerData.tsx
+++ b/app/routes/event/team/components/playerData.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from "react";
-import { Await } from "react-router";
 import { CharacterName } from "~/components/display/characterName";
 import { ClassDisplay } from "~/components/display/classDisplay";
 import { H3 } from "~/components/display/headers";
@@ -10,12 +8,9 @@ import { Card } from "~/components/ui/card";
 import { makeRaiderIOClassSpec } from "~/lib/classes";
 import { Route } from "../+types/route";
 
-type PlayerData = NonNullable<
-  Awaited<Route.ComponentProps["loaderData"]["playersPromises"][number]>
->;
-type PlayerDataPromise = Promise<PlayerData | null>;
+type PlayerDataType = Route.ComponentProps["loaderData"]["playersData"][number];
 
-function PlayerDataInternal(player: PlayerData) {
+function PlayerDataInternal(player: NonNullable<PlayerDataType>) {
   const playerScore =
     player.mythic_plus_best_runs?.reduce((acc, run) => acc + run.score, 0) || 0;
   return (
@@ -121,14 +116,7 @@ function MissingPlayerData() {
   );
 }
 
-export function PlayerData({ player }: { player: PlayerDataPromise }) {
-  return (
-    <Suspense fallback={<div>loading...</div>}>
-      <Await resolve={player} errorElement={<MissingPlayerData />}>
-        {(player) =>
-          player ? <PlayerDataInternal {...player} /> : <MissingPlayerData />
-        }
-      </Await>
-    </Suspense>
-  );
+export function PlayerData({ player }: { player: PlayerDataType }) {
+  if (!player) return <MissingPlayerData />;
+  return <PlayerDataInternal {...player} />;
 }

--- a/app/routes/event/team/route.tsx
+++ b/app/routes/event/team/route.tsx
@@ -30,8 +30,7 @@ export const loader = async ({ params: { slug, id } }: Route.LoaderArgs) => {
 
   const client = RaiderIOClient.getInstance();
 
-  // Keep playersPromises for player profile cards (gear/spec display)
-  const playersPromises = getPlayersPromises(team, client);
+  const playersData = await Promise.all(getPlayersPromises(team, client));
 
   const mythicData = await getMythicDataForTeam(team, {
     after: event?.startDate,
@@ -40,14 +39,14 @@ export const loader = async ({ params: { slug, id } }: Route.LoaderArgs) => {
 
   return {
     team,
-    playersPromises,
+    playersData,
     mythicData,
   };
 };
 export const action = async ({}: Route.ActionArgs) => ({});
 
 export default function TeamShow({
-  loaderData: { team, playersPromises, mythicData },
+  loaderData: { team, playersData, mythicData },
   params: { slug },
 }: Route.ComponentProps) {
   //need to make a func to detect if a team has provided a banner photo or not
@@ -111,8 +110,8 @@ export default function TeamShow({
               // </div>
             )}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {playersPromises.map((playerPromise, index) => (
-                <PlayerData player={playerPromise} key={index} />
+              {playersData.map((player, index) => (
+                <PlayerData player={player} key={index} />
               ))}
             </div>
             <MythicInfo

--- a/app/routes/event/team/route.tsx
+++ b/app/routes/event/team/route.tsx
@@ -7,8 +7,8 @@ import {
   calculateAugmentedBestMythicsAndTotalScore,
   calculateBestMythicsAndTotalScore,
   getPlayersPromises,
-  parseMythicDataPerTeam,
 } from "~/lib/mythics";
+import { getMythicDataForTeam } from "~/lib/runData.server";
 import { RaiderIOClient } from "~/lib/raiderIO";
 import { Route } from "./+types/route";
 import TeamDungeonRuns from "./components/dungeonRuns";
@@ -26,34 +26,25 @@ export const loader = async ({ params: { slug, id } }: Route.LoaderArgs) => {
     return redirect(`/event/${slug}`);
   }
 
+  const event = await db.event.findFirst({ where: { slug } });
+
   const client = RaiderIOClient.getInstance();
 
+  // Keep playersPromises for player profile cards (gear/spec display)
   const playersPromises = getPlayersPromises(team, client);
+
+  const mythicData = await getMythicDataForTeam(team, {
+    after: event?.startDate,
+    before: event?.endDate,
+  });
 
   return {
     team,
     playersPromises,
-    mythicData: null,
-  };
-};
-export const action = async ({}: Route.ActionArgs) => ({});
-
-export const clientLoader = async ({
-  serverLoader,
-}: Route.ClientLoaderArgs) => {
-  const serverRes = await serverLoader();
-
-  const mythicData = await parseMythicDataPerTeam(
-    serverRes.team,
-    serverRes.playersPromises
-  );
-
-  return {
-    ...serverRes,
     mythicData,
   };
 };
-clientLoader.hydrate = true;
+export const action = async ({}: Route.ActionArgs) => ({});
 
 export default function TeamShow({
   loaderData: { team, playersPromises, mythicData },

--- a/app/routes/event/team/route.tsx
+++ b/app/routes/event/team/route.tsx
@@ -6,9 +6,8 @@ import { db } from "~/lib/db.server";
 import {
   calculateAugmentedBestMythicsAndTotalScore,
   calculateBestMythicsAndTotalScore,
-  getPlayersPromises,
 } from "~/lib/mythics";
-import { getMythicDataForTeam } from "~/lib/runData.server";
+import { getCachedPlayerProfile, getMythicDataForTeam } from "~/lib/runData.server";
 import { RaiderIOClient } from "~/lib/raiderIO";
 import { Route } from "./+types/route";
 import TeamDungeonRuns from "./components/dungeonRuns";
@@ -28,9 +27,34 @@ export const loader = async ({ params: { slug, id } }: Route.LoaderArgs) => {
 
   const event = await db.event.findFirst({ where: { slug } });
 
-  const client = RaiderIOClient.getInstance();
+  // Try cached profiles first, fall back to live API for any missing
+  const playersData = await Promise.all(
+    team.players.map(async (player) => {
+      if (!player.playerServer || !player.playerName) return null;
 
-  const playersData = await Promise.all(getPlayersPromises(team, client));
+      const cached = await getCachedPlayerProfile(player.id);
+      if (cached) return cached;
+
+      console.log(
+        `[TeamLoader] Cache empty for "${player.playerName}", fetching from RaiderIO API`
+      );
+      const client = RaiderIOClient.getInstance();
+      return client.character.getCharacterProfile({
+        region: "us",
+        realm: player.playerServer,
+        name: player.playerName,
+        fields: {
+          gear: true,
+          mythic_plus_best_runs: { all: true },
+          mythic_plus_alternate_runs: { all: true },
+          mythic_plus_highest_level_runs: true,
+          mythic_plus_recent_runs: true,
+          mythic_plus_previous_weekly_highest_level_runs: true,
+          mythic_plus_weekly_highest_level_runs: true,
+        },
+      });
+    })
+  );
 
   const mythicData = await getMythicDataForTeam(team, {
     after: event?.startDate,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wow-rando-comp",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "react-router dev",

--- a/prisma/migrations/20260221223903_add_mythic_run_caching/migration.sql
+++ b/prisma/migrations/20260221223903_add_mythic_run_caching/migration.sql
@@ -1,0 +1,77 @@
+-- CreateTable
+CREATE TABLE "MythicPlusRun" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "keystoneRunId" INTEGER NOT NULL,
+    "dungeon" TEXT NOT NULL,
+    "shortName" TEXT NOT NULL,
+    "mythicLevel" INTEGER NOT NULL,
+    "completedAt" DATETIME NOT NULL,
+    "clearTimeMs" INTEGER NOT NULL,
+    "parTimeMs" INTEGER NOT NULL,
+    "numKeystoneUpgrades" INTEGER NOT NULL,
+    "mapChallengeModeId" INTEGER NOT NULL,
+    "zoneId" INTEGER NOT NULL,
+    "zoneExpansionId" INTEGER NOT NULL,
+    "iconUrl" TEXT NOT NULL,
+    "backgroundImageUrl" TEXT NOT NULL,
+    "score" REAL NOT NULL,
+    "url" TEXT NOT NULL,
+    "affixes" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "PlayerRun" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "playerId" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    CONSTRAINT "PlayerRun_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "Player" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "PlayerRun_runId_fkey" FOREIGN KEY ("runId") REFERENCES "MythicPlusRun" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "SyncLog" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "eventId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "playersSynced" INTEGER NOT NULL DEFAULT 0,
+    "runsUpserted" INTEGER NOT NULL DEFAULT 0,
+    "errorMessage" TEXT,
+    "startedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" DATETIME,
+    "durationMs" INTEGER,
+    CONSTRAINT "SyncLog_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Event" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "startDate" DATETIME,
+    "endDate" DATETIME,
+    "status" TEXT NOT NULL DEFAULT 'ACTIVE',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_Event" ("createdAt", "id", "name", "slug", "updatedAt") SELECT "createdAt", "id", "name", "slug", "updatedAt" FROM "Event";
+DROP TABLE "Event";
+ALTER TABLE "new_Event" RENAME TO "Event";
+CREATE UNIQUE INDEX "Event_slug_key" ON "Event"("slug");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MythicPlusRun_keystoneRunId_key" ON "MythicPlusRun"("keystoneRunId");
+
+-- CreateIndex
+CREATE INDEX "MythicPlusRun_dungeon_idx" ON "MythicPlusRun"("dungeon");
+
+-- CreateIndex
+CREATE INDEX "MythicPlusRun_completedAt_idx" ON "MythicPlusRun"("completedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PlayerRun_playerId_runId_key" ON "PlayerRun"("playerId", "runId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,7 +49,8 @@ model Player {
   playerServer String?
   team         Team?       @relation(fields: [teamId], references: [id])
   event        Event       @relation(fields: [eventId], references: [id])
-  playerRuns   PlayerRun[]
+  playerRuns     PlayerRun[]
+  cachedProfile  CachedPlayerProfile?
 }
 
 model Team {
@@ -128,6 +129,27 @@ model SyncLog {
   startedAt     DateTime   @default(now())
   completedAt   DateTime?
   durationMs    Int?
+}
+
+model CachedPlayerProfile {
+  id                String   @id @default(cuid())
+  playerId          String   @unique
+  player            Player   @relation(fields: [playerId], references: [id])
+  name              String
+  race              String
+  class             String
+  activeSpecName    String
+  activeSpecRole    String
+  faction           String
+  region            String
+  realm             String
+  thumbnailUrl      String
+  profileUrl        String
+  itemLevelEquipped Int
+  gearItems         String // JSON blob of gear.items
+  bestRuns          String // JSON blob of mythic_plus_best_runs
+  cachedAt          DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 }
 
 enum SyncStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,17 +16,27 @@ datasource db {
 }
 
 model Event {
-  id        String   @id @default(cuid())
-  slug      String   @unique
+  id        String      @id @default(cuid())
+  slug      String      @unique
   name      String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  startDate DateTime?
+  endDate   DateTime?
+  status    EventStatus @default(ACTIVE)
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
   players   Player[]
   teams     Team[]
+  syncLogs  SyncLog[]
+}
+
+enum EventStatus {
+  ACTIVE
+  ENDED
+  ARCHIVED
 }
 
 model Player {
-  id           String   @id @default(cuid())
+  id           String      @id @default(cuid())
   nickname     String
   main         String?
   playerName   String?
@@ -34,11 +44,12 @@ model Player {
   spec         String?
   eventId      String
   teamId       String?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt    DateTime    @default(now())
+  updatedAt    DateTime    @updatedAt
   playerServer String?
-  team         Team?    @relation(fields: [teamId], references: [id])
-  event        Event    @relation(fields: [eventId], references: [id])
+  team         Team?       @relation(fields: [teamId], references: [id])
+  event        Event       @relation(fields: [eventId], references: [id])
+  playerRuns   PlayerRun[]
 }
 
 model Team {
@@ -68,4 +79,60 @@ enum Role {
   mdps
   tank
   healer
+}
+
+model MythicPlusRun {
+  id                   String      @id @default(cuid())
+  keystoneRunId        Int         @unique
+  dungeon              String
+  shortName            String
+  mythicLevel          Int
+  completedAt          DateTime
+  clearTimeMs          Int
+  parTimeMs            Int
+  numKeystoneUpgrades  Int
+  mapChallengeModeId   Int
+  zoneId               Int
+  zoneExpansionId      Int
+  iconUrl              String
+  backgroundImageUrl   String
+  score                Float
+  url                  String
+  affixes              String // JSON string of Affix[]
+  createdAt            DateTime    @default(now())
+  updatedAt            DateTime    @updatedAt
+  playerRuns           PlayerRun[]
+
+  @@index([dungeon])
+  @@index([completedAt])
+}
+
+model PlayerRun {
+  id       String        @id @default(cuid())
+  playerId String
+  runId    String
+  player   Player        @relation(fields: [playerId], references: [id])
+  run      MythicPlusRun @relation(fields: [runId], references: [id])
+
+  @@unique([playerId, runId])
+}
+
+model SyncLog {
+  id            String     @id @default(cuid())
+  eventId       String
+  event         Event      @relation(fields: [eventId], references: [id])
+  status        SyncStatus
+  playersSynced Int        @default(0)
+  runsUpserted  Int        @default(0)
+  errorMessage  String?
+  startedAt     DateTime   @default(now())
+  completedAt   DateTime?
+  durationMs    Int?
+}
+
+enum SyncStatus {
+  RUNNING
+  COMPLETED
+  FAILED
+  PARTIAL
 }


### PR DESCRIPTION
## Summary

- **Persist M+ run data to SQLite** so historical event data survives server restarts and RaiderIO profile updates
- **Background sync scheduler** fetches fresh data from RaiderIO every 15 minutes for all active events
- **Route loaders read from DB cache first**, falling back to the live API when the cache is empty
- **Event lifecycle controls** let admins set start/end dates and mark events as ended to freeze their data

## Implementation Details

### New Database Models

| Model | Purpose |
|-------|---------|
| `MythicPlusRun` | Stores every M+ run with a unique `keystoneRunId`. Indexed on `dungeon` and `completedAt` for efficient queries. Affixes stored as JSON string. |
| `PlayerRun` | Join table linking players to runs. Unique constraint on `[playerId, runId]` prevents duplicates. This is how we know which players participated in which runs. |
| `SyncLog` | Audit trail for sync jobs — tracks player count, run count, duration, errors, and status per event per sync. |
| `EventStatus` enum | `ACTIVE` (default), `ENDED`, `ARCHIVED` — controls whether the scheduler syncs an event. |
| `Event` extensions | `startDate`, `endDate` (optional) for date-bounded run queries, `status` for lifecycle control. |

### Data Access Layer (`app/lib/runData.server.ts`)

- **`upsertRunsForPlayer(playerId, runs[])`** — Upserts `MythicPlusRun` rows keyed on `keystoneRunId` and creates `PlayerRun` links. Used by the sync job.
- **`getCachedRunsForTeam(team, {after?, before?})`** — Queries `PlayerRun` joined with `MythicPlusRun` for all players on a team. Groups by `keystoneRunId`, builds participant lists, filters to runs with >= 3 team members, sorts by level/score/name. Returns `MythicData[]` — the exact same shape consumed by existing scoring functions.
- **`getMythicDataForTeam(team, {after?, before?})`** — Tries `getCachedRunsForTeam()` first. If the DB cache is empty (no sync has run yet), falls back to live RaiderIO API via `getPlayersPromises()` + `parseMythicDataPerTeam()`. This means the app works identically before the first sync completes.

### How the Background Sync Works

```
Server Boot
    │
    ▼
entry.server.tsx imports init.server.ts (side-effect)
    │
    ▼
init.server.ts calls startScheduler()
    │
    ├─► Runs syncActiveEvents() immediately
    │
    └─► setInterval(syncActiveEvents, SYNC_INTERVAL_MS)  // default: 15 min
            │
            ▼
        For each event with status=ACTIVE:
            │
            ├─ Create SyncLog with status=RUNNING
            │
            ├─ For each player with playerName/playerServer:
            │     │
            │     ├─ Fetch all M+ run types from RaiderIO API
            │     │   (best, alternate, highest, recent, weekly, prev_weekly)
            │     │
            │     ├─ Deduplicate runs by keystone_run_id
            │     │
            │     ├─ Upsert MythicPlusRun rows + PlayerRun links
            │     │
            │     ├─ On error: log, continue with next player
            │     │
            │     └─ Sleep SYNC_PLAYER_DELAY_MS (default: 200ms)
            │
            └─ Update SyncLog with final status:
                 COMPLETED (all succeeded)
                 PARTIAL (some players failed)
                 FAILED (no players synced)
```

**Configuration via environment variables:**

| Variable | Default | Description |
|----------|---------|-------------|
| `SYNC_ENABLED` | `true` | Set to `false` to disable the scheduler entirely |
| `SYNC_INTERVAL_MS` | `900000` (15 min) | How often the sync runs |
| `SYNC_PLAYER_DELAY_MS` | `200` | Delay between player API calls to respect RaiderIO rate limits |

### Route Loader Migration

All route loaders now call `getMythicDataForTeam()` instead of `getPlayersPromises()` + `parseMythicDataPerTeam()`:

| Route | Changes |
|-------|---------|
| `event/show` | Uses `getMythicDataForTeam` with event date bounds. Removed `RaiderIOClient` import. |
| `event/team` | Server loader resolves mythic data directly. **Removed `clientLoader`**. Kept `playersPromises` for player profile cards (gear/spec display). |
| `event/player` | Server loader resolves mythic data. **Removed `clientLoader`**. |
| `event/stats` | Uses `getMythicDataForTeam` per team. |
| `event/lists` | Same pattern. **Removed `clientLoader`**. |

All player includes updated to `include: { team: true }` to satisfy the `DBPlayerType` shape needed by `getCachedRunsForTeam`.

The downstream scoring functions (`calculateBestMythicsAndTotalScore`, `calculateAugmentedBestMythicsAndTotalScore`, etc.) and all UI components remain **completely unchanged** since they receive the same `MythicData[]` type.

### Event Lifecycle (Edit Page)

New "Event Settings" card (collapsed by default) with:
- **Start Date** / **End Date** — datetime-local inputs, stored as `DateTime?` on the Event model
- **Status** dropdown — Active / Ended / Archived

When an event is `ENDED` or `ARCHIVED`:
- The scheduler skips it (no more API calls to RaiderIO)
- All cached run data stays in the DB permanently
- Route loaders query runs filtered by `startDate`/`endDate`, showing exactly the runs from the event period

### File Summary

| File | Action |
|------|--------|
| `prisma/schema.prisma` | Modified — add MythicPlusRun, PlayerRun, SyncLog, EventStatus, Event fields |
| `prisma/migrations/.../migration.sql` | New — migration for all schema changes |
| `app/lib/runData.server.ts` | New — DB read/write for run data + `getMythicDataForTeam` |
| `app/lib/sync.server.ts` | New — sync job logic |
| `app/lib/scheduler.server.ts` | New — setInterval scheduler with start/stop |
| `app/lib/init.server.ts` | New — server startup hook |
| `app/entry.server.tsx` | New — server entry point importing init.server |
| `app/lib/env.server.ts` | Modified — add SYNC_INTERVAL_MS, SYNC_ENABLED, SYNC_PLAYER_DELAY_MS |
| `app/routes/event/show/route.tsx` | Modified — use DB cache in loader |
| `app/routes/event/team/route.tsx` | Modified — use DB cache, remove clientLoader |
| `app/routes/event/player/route.tsx` | Modified — use DB cache, remove clientLoader |
| `app/routes/event/stats/route.tsx` | Modified — use DB cache |
| `app/routes/event/lists/route.tsx` | Modified — use DB cache, remove clientLoader |
| `app/routes/event/edit.tsx` | Modified — add event lifecycle controls |

**No new dependencies** — `setInterval` for scheduling, SQLite handles persistence.

## Test Plan

- [ ] **Schema migration**: Run `npx prisma migrate dev` and confirm it applies cleanly with no errors
- [ ] **Server startup**: Start dev server (`npm run dev`), check console for `[Scheduler] Starting sync scheduler (interval: 900000ms)` and `[Sync] Starting sync for event...` log lines
- [ ] **First sync completes**: After ~30-60s, check console for `[Sync] Completed sync for...` with player/run counts. Verify no `FAILED` status.
- [ ] **DB populated**: Open Prisma Studio (`npx prisma studio`) and verify `MythicPlusRun`, `PlayerRun`, and `SyncLog` tables have data
- [ ] **Leaderboard page**: Load an event's leaderboard — should render identically to before (teams, scores, mythic data all present)
- [ ] **Team detail page**: Load a team page — player cards should still show gear/spec, mythic runs should display correctly with participant badges
- [ ] **Player detail page**: Load a player page — character data and team mythic data should display
- [ ] **Stats page**: Load the stats page — run counts, dungeon stats, timing data should all render
- [ ] **Lists page**: Load the lists page — team data tables should show mythic data
- [ ] **Data persistence**: Stop the server, restart it. Pages should load from DB cache without waiting for API calls. Check that no "fetching from RaiderIO API" fallback messages appear in the console.
- [ ] **Event settings**: Go to an event's edit page, expand "Event Settings", set a start date and end date, save. Verify the dates persist on page reload.
- [ ] **Date filtering**: Set an event's start date to a future date, save. The leaderboard should show no runs (since all cached runs are before the start date). Reset the start date to verify runs reappear.
- [ ] **End event**: Change an event's status to "Ended". Wait for the next sync cycle. Verify the console shows `[Sync] No active events to sync` (or skips the ended event). Verify the leaderboard still shows all cached data.
- [ ] **Disable sync**: Set `SYNC_ENABLED=false` in `.env`, restart the server. Verify console shows `[Scheduler] Sync is disabled`. Pages should still load from DB cache.
- [ ] **Build check**: Run `npx vite build` and confirm it completes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)